### PR TITLE
watchtower/client: immediately negotiate sessions with first candidate tower

### DIFF
--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -792,6 +792,12 @@ func (c *TowerClient) backupDispatcher() {
 			case msg := <-c.newTowers:
 				msg.errChan <- c.handleNewTower(msg)
 
+				// We do not currently have an active session, so notify the
+				// session negotiator of newly added tower. This avoids us
+				// from having to wait for the exponential backoff delay
+				// in session negotiation.
+				c.negotiator.NotifyNewTower()
+
 			// A tower has been requested to be removed. We'll
 			// immediately return an error as we want to avoid the
 			// possibility of a new session being negotiated with


### PR DESCRIPTION
Whether or not we have any candidate towers, the session negotiator will begin attempting to negotiate a session. While there are no candidate towers the negotiator will just churn with exponential backoff. Currently we won't establish a usable session until after the exponential backup delay times out. Instead we could break out of the delay and immediately negotiate a session with the newly added tower so we can get to backing up those payment channel state updates!