### PR TITLE
lncli: allow QueryRoutes RPC to begin pathfinding at arbitrary source…

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -1009,6 +1009,11 @@ var queryRoutesCommand = cli.Command{
 	ArgsUsage:   "dest amt",
 	Flags: []cli.Flag{
 		cli.StringFlag{
+			Name: "src",
+			Usage: "the 33-byte hex-encoded public key from " +
+				"which to begin pathfinding",
+		},
+		cli.StringFlag{
 			Name: "dest",
 			Usage: "the 33-byte hex-encoded public key for the payment " +
 				"destination",
@@ -1060,6 +1065,7 @@ func queryRoutes(ctx *cli.Context) error {
 	defer cleanUp()
 
 	var (
+		src  string
 		dest string
 		amt  int64
 		err  error
@@ -1075,6 +1081,19 @@ func queryRoutes(ctx *cli.Context) error {
 		args = args.Tail()
 	default:
 		return fmt.Errorf("dest argument missing")
+	}
+
+	// Optionally include an arbitrary source node
+	// from which to begin pathfinding.
+	// NOTE: We do no validation that the key is valid here.
+	// We'll let the backend do that!
+	switch {
+	case ctx.IsSet("src"):
+		dest = ctx.String("src")
+	case args.Present():
+		dest = args.First()
+		args = args.Tail()
+	default:
 	}
 
 	switch {
@@ -1120,6 +1139,7 @@ func queryRoutes(ctx *cli.Context) error {
 	}
 
 	req := &lnrpc.QueryRoutesRequest{
+		SourcePubKey:      src,
 		PubKey:            dest,
 		Amt:               amt,
 		FeeLimit:          feeLimit,


### PR DESCRIPTION
… node

The functionality for this RPC to handle arbitrary source nodes already exists. We just surface this functionality to end users via a new flag on the the QueryRoutes command in `lncli`

## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.