### PR TITLE
multi: explicitly acknowledge successful HTLC dispatch

### DIFF
--- a/channeldb/mp_payment.go
+++ b/channeldb/mp_payment.go
@@ -45,6 +45,10 @@ type HTLCAttemptInfo struct {
 	// in which the payment's PaymentHash in the PaymentCreationInfo should
 	// be used.
 	Hash *lntypes.Hash
+
+	// Acknowledged indicates whether the HTLC attempt was successfully
+	// sent to the switch.
+	Acknowledged bool
 }
 
 // NewHtlcAttempt creates a htlc attempt.

--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -1125,6 +1125,11 @@ func serializeHTLCAttemptInfo(w io.Writer, a *HTLCAttemptInfo) error {
 		return err
 	}
 
+	// Serialize the Acknowledged field.
+	if err := WriteElements(w, a.Acknowledged); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -1177,6 +1182,16 @@ func deserializeHTLCAttemptInfo(r io.Reader) (*HTLCAttemptInfo, error) {
 	}
 
 	a.Route.FirstHopWireCustomRecords = customRecords
+
+	// Deserialize the Acknowledged field.
+	if err := ReadElements(r, &a.Acknowledged); err != nil {
+		// For backward compatibility, default to false if not present.
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			a.Acknowledged = false
+		} else {
+			return nil, err
+		}
+	}
 
 	return a, nil
 }

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -186,7 +186,18 @@ func (p *paymentLifecycle) resumePayment(ctx context.Context) ([32]byte,
 		log.Infof("Resuming HTLC attempt %v for payment %v",
 			a.AttemptID, p.identifier)
 
-		p.resultCollector(&a)
+		if a.Acknowledged {
+			// Proceed to track acknowledged attempts.
+			p.resultCollector(&a)
+		} else {
+			// Retry sending non-acknowledged attempts.
+			err := p.retrySendHTLC(&a)
+			if err != nil {
+				log.Errorf("Failed to retry non-acknowledged "+
+					"HTLC attempt %v for payment %v: %v",
+					a.AttemptID, p.identifier, err)
+			}
+		}
 	}
 
 	// exitWithErr is a helper closure that logs and returns an error.
@@ -321,6 +332,55 @@ lifecycle:
 
 	// Otherwise return the payment failure reason.
 	return [32]byte{}, nil, *failure
+}
+
+func (p *paymentLifecycle) retrySendHTLC(attempt *channeldb.HTLCAttempt) error {
+	log.Infof("Retrying HTLC attempt %v for payment %v",
+		attempt.AttemptID, p.identifier)
+
+	// Recreate the HTLC add message using the original route and attempt data.
+	htlcAdd := &lnwire.UpdateAddHTLC{
+		Amount:        attempt.Route.FirstHopAmount.Val.Int(),
+		Expiry:        attempt.Route.TotalTimeLock,
+		PaymentHash:   *attempt.Hash,
+		CustomRecords: attempt.Route.FirstHopWireCustomRecords,
+	}
+
+	// Generate the raw encoded sphinx packet to include with the HTLC.
+	onionBlob, _, err := GenerateSphinxPacket(
+		&attempt.Route, attempt.Hash[:], attempt.SessionKey(),
+	)
+	if err != nil {
+		log.Errorf("Failed to create onion blob: attempt=%d in "+
+			"payment=%v, err=%v", attempt.AttemptID, p.identifier, err)
+		return err
+	}
+	copy(htlcAdd.OnionBlob[:], onionBlob)
+
+	// Send the HTLC to the switch.
+	firstHop := lnwire.NewShortChanIDFromInt(attempt.Route.Hops[0].ChannelID)
+	err = p.router.cfg.Payer.SendHTLC(firstHop, attempt.AttemptID, htlcAdd)
+	if err != nil {
+		log.Errorf("Failed to retry HTLC attempt %d for payment %v: %v",
+			attempt.AttemptID, p.identifier, err)
+		return err
+	}
+
+	// Mark the attempt as acknowledged.
+	err = p.router.cfg.Control.AcknowledgeAttempt(p.identifier, attempt.AttemptID)
+	if err != nil {
+		log.Warnf("Failed to mark attempt %d as acknowledged: %v",
+			attempt.AttemptID, err)
+		// Proceed as best effort.
+	}
+
+	log.Infof("Successfully retried and acknowledged HTLC attempt %v "+
+		"for payment %v", attempt.AttemptID, p.identifier)
+
+	// Spawn a result collector for the retried attempt.
+	p.resultCollector(attempt)
+
+	return nil
 }
 
 // checkContext checks whether the payment context has been canceled.
@@ -723,6 +783,16 @@ func (p *paymentLifecycle) sendAttempt(
 			"switch: %v", attempt.AttemptID, p.identifier, err)
 
 		return p.handleSwitchErr(attempt, err)
+	}
+
+	// Mark the attempt as acknowledged in the ControlTower.
+	err = p.router.cfg.Control.AcknowledgeAttempt(
+		p.identifier, attempt.AttemptID,
+	)
+	if err != nil {
+		log.Warnf("Failed to mark attempt %d as acknowledged: %v",
+			attempt.AttemptID, err)
+		// Proceed as best effort.
 	}
 
 	log.Debugf("Attempt %v for payment %v successfully sent to switch, "+


### PR DESCRIPTION
## Change Description
We expand the _**ChannelRouter**_ to handle new failure modes when _**SendHTLC**_ is implemented using RPCs over a network - as is the case when Router and Switch run in separate processes.

The **_ChannelRouter_** needs to distinguish on startup between an attempt that was initiated successfully and an attempt for which it is not known whether it initiated successfully. It must attempt to track the result only for attempts which are known to have been initiated successfully. Otherwise, since we base retry decision of the result of attempt tracking, we risk duplicate attempts being made if SendHTLC is implemented via RPC between two processes communicating over async network.
- Here “initiated successfully” means an explicit response/acknowledgement from the backend server processing the request. Network/gRPC Errors alone are not sufficient to make this determination.
- This persisting of the acknowledgement from the Switch server (local or remote) can be done on a best effort basis.
- NOTE: This requires an **_lnd_** change. It allows us to handle a class of failure mode that is not present when Router + Switch run in the same process. The acknowledgement is **_not_** needed for correct function when the Router + Switch run in the _same_ process.

This sequence—**_RegisterAttempt_**, **_SendHTLC_**, and **_AcknowledgeAttempt_**—is critical in a distributed environment to:
1. Persist the intent to send HTLCs (**_RegisterAttempt_**).
2. Execute the actual HTLC delivery (**_SendHTLC_**).
3. Resolve ambiguity about the HTLC’s state (**_AcknowledgeAttempt_**).

- Procedure on Startup:
    - Query the DB for all items with "initiated but not yet complete" status.
    - Classify items based on a “SendHTLC acknowledgement status":
        * For KNOWN_STARTED: Begin tracking with **_GetAttemptResult_**.
        * For AMBIGUOUS: Retry **_SendHTLC_**.
- Retry and Transition Logic:
    - For AMBIGUOUS attempts, call **_SendHTLC_**:
        * If **_SendHTLC_** succeeds, update the state to _acknowledged_ and proceed to **_GetAttemptResult_**.
        * If **_SendHTLC_** returns an "AlreadyExists" response, update the state to _acknowledged_ and proceed to **_GetAttemptResult_**.
        * If **_SendHTLC_** fails with a retry-able error, path-find and make another attempt.
        * If **_SendHTLC_** fails with a terminal error, mark the attempt and payment as failed.
- NOTE: **_GetAttemptResult_** CANNOT be used to resolve the ambiguity when communication happens over the network!

### TODO
- Any migration needed?