### PR TITLE
routing: call SendHTLC when resuming attempts

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -530,3 +530,27 @@ type AuxTrafficShaper interface {
 	// meaning that it's from a custom channel.
 	IsCustomHTLC(htlcRecords lnwire.CustomRecords) bool
 }
+
+// AttemptStore defines the interface for storing and managing the results
+// of HTLC payment attempts. It is designed to support both local and remote
+// lifecycle controllers, allowing full control over result storage and cleanup.
+type AttemptStore interface {
+	// StoreResult stores the result of a given payment attempt (identified
+	// by attemptID). This will be called when a result is received from the
+	// network.
+	StoreResult(attemptID uint64, result *networkResult) error
+
+	// GetResult returns the network result for the specified attempt ID if
+	// it's available.
+	GetResult(attemptID uint64) (*networkResult, error)
+
+	// SubscribeResult subscribes to be notified when a result for a
+	// specific attempt ID becomes available. It returns a channel that will
+	// receive the result.
+	SubscribeResult(attemptID uint64) (<-chan *networkResult, error)
+
+	// CleanStore removes all attempt results from the store except for
+	// those listed in the keepPids map. This allows for a "delete all except"
+	// approach to cleanup.
+	CleanStore(keepPids map[uint64]struct{}) error
+}

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -535,6 +535,10 @@ type AuxTrafficShaper interface {
 // of HTLC payment attempts. It is designed to support both local and remote
 // lifecycle controllers, allowing full control over result storage and cleanup.
 type AttemptStore interface {
+	// Initialize the payment attempt. This should be called before actually
+	// dispatching the HTLC to the network.
+	InitAttempt(attemptID uint64) error
+
 	// StoreResult stores the result of a given payment attempt (identified
 	// by attemptID). This will be called when a result is received from the
 	// network.

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -542,6 +542,11 @@ type AttemptStore interface {
 
 	// GetResult returns the network result for the specified attempt ID if
 	// it's available.
+	//
+	// NOTE: This method will return ErrPaymentIDNotFound for attempts that
+	// have been initialized via InitAttempt but for which a final result
+	// (settle/fail) has not yet been stored. This is to preserve legacy
+	// behavior.
 	GetResult(attemptID uint64) (*networkResult, error)
 
 	// SubscribeResult subscribes to be notified when a result for a

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -106,7 +106,7 @@ func newNetworkResultStore(db kvdb.Backend) *networkResultStore {
 
 // storeResult stores the networkResult for the given attemptID, and notifies
 // any subscribers.
-func (store *networkResultStore) storeResult(attemptID uint64,
+func (store *networkResultStore) StoreResult(attemptID uint64,
 	result *networkResult) error {
 
 	// We get a mutex for this attempt ID. This is needed to ensure
@@ -154,7 +154,7 @@ func (store *networkResultStore) storeResult(attemptID uint64,
 
 // subscribeResult is used to get the HTLC attempt result for the given attempt
 // ID.  It returns a channel on which the result will be delivered when ready.
-func (store *networkResultStore) subscribeResult(attemptID uint64) (
+func (store *networkResultStore) SubscribeResult(attemptID uint64) (
 	<-chan *networkResult, error) {
 
 	// We get a mutex for this payment ID. This is needed to ensure
@@ -214,7 +214,7 @@ func (store *networkResultStore) subscribeResult(attemptID uint64) (
 
 // getResult attempts to immediately fetch the result for the given pid from
 // the store. If no result is available, ErrPaymentIDNotFound is returned.
-func (store *networkResultStore) getResult(pid uint64) (
+func (store *networkResultStore) GetResult(pid uint64) (
 	*networkResult, error) {
 
 	var result *networkResult
@@ -258,7 +258,7 @@ func fetchResult(tx kvdb.RTx, pid uint64) (*networkResult, error) {
 // should be taken to ensure no new payment attempts are being made
 // concurrently while this process is ongoing, as its result might end up being
 // deleted.
-func (store *networkResultStore) cleanStore(keep map[uint64]struct{}) error {
+func (store *networkResultStore) CleanStore(keep map[uint64]struct{}) error {
 	return kvdb.Update(store.backend, func(tx kvdb.RwTx) error {
 		networkResults, err := tx.CreateTopLevelBucket(
 			networkResultStoreBucketKey,

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -117,7 +117,7 @@ func (store *networkResultStore) StoreResult(attemptID uint64,
 
 	log.Debugf("Storing result for attemptID=%v", attemptID)
 
-	// Serialize the payment result.
+	// Handle finalized result (success or failure).
 	var b bytes.Buffer
 	if err := serializeNetworkResult(&b, result); err != nil {
 		return err
@@ -141,13 +141,16 @@ func (store *networkResultStore) StoreResult(attemptID uint64,
 	}
 
 	// Now that the result is stored in the database, we can notify any
-	// active subscribers.
-	store.resultsMtx.Lock()
-	for _, res := range store.results[attemptID] {
-		res <- result
+	// active subscribers - but only if this isn't an initialized attempt
+	// awaiting a settle/fail result from the network.
+	if result.msg.MsgType() != lnwire.MsgPendingNetworkResult {
+		store.resultsMtx.Lock()
+		for _, res := range store.results[attemptID] {
+			res <- result
+		}
+		delete(store.results, attemptID)
+		store.resultsMtx.Unlock()
 	}
-	delete(store.results, attemptID)
-	store.resultsMtx.Unlock()
 
 	return nil
 }
@@ -194,11 +197,20 @@ func (store *networkResultStore) SubscribeResult(attemptID uint64) (
 		return nil, err
 	}
 
-	// If the result was found, we can send it on the result channel
-	// imemdiately.
+	// If a result is back from the network, we can send it on the result
+	// channel immemdiately. If the result is still our initialized place
+	// holder, then treat it as not yet available.
 	if result != nil {
-		resultChan <- result
-		return resultChan, nil
+		if result.msg.MsgType() != lnwire.MsgPendingNetworkResult {
+			log.Debugf("Obtained full result for attemptID=%v",
+				attemptID)
+
+			resultChan <- result
+			return resultChan, nil
+		}
+
+		log.Debugf("Awaiting result (settle/fail) for attemptID=%v",
+			attemptID)
 	}
 
 	// Otherwise we store the result channel for when the result is
@@ -212,8 +224,13 @@ func (store *networkResultStore) SubscribeResult(attemptID uint64) (
 	return resultChan, nil
 }
 
-// getResult attempts to immediately fetch the result for the given pid from
-// the store. If no result is available, ErrPaymentIDNotFound is returned.
+// GetResult attempts to immediately fetch the *final* network result for the
+// given attempt ID from the store. If no result is available, or if the only
+// entry is an initialization placeholder (e.g. created via InitAttempt),
+// ErrPaymentIDNotFound is returned to signal that the result is not yet
+// available.
+//
+// NOTE: This method does not currently acquire the result subscription mutex.
 func (store *networkResultStore) GetResult(pid uint64) (
 	*networkResult, error) {
 
@@ -221,7 +238,18 @@ func (store *networkResultStore) GetResult(pid uint64) (
 	err := kvdb.View(store.backend, func(tx kvdb.RTx) error {
 		var err error
 		result, err = fetchResult(tx, pid)
-		return err
+		if err != nil {
+			return err
+		}
+
+		// If the attempt is still in-flight, treat it as not yet
+		// available to preserve existing expectation for the behavior
+		// of this method.
+		if result.msg.MsgType() == lnwire.MsgPendingNetworkResult {
+			return ErrPaymentIDNotFound
+		}
+
+		return nil
 	}, func() {
 		result = nil
 	})

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -104,6 +104,89 @@ func newNetworkResultStore(db kvdb.Backend) *networkResultStore {
 	}
 }
 
+// InitAttempt initializes the payment attempt with the given attemptID.
+//
+// If any record (even a pending result placeholder) already exists in the
+// store, this method returns ErrPaymentIDAlreadyExists. This guarantees that
+// only one HTLC will be initialized and dispatched for a given attempt ID until
+// the ID is explicitly cleaned from attempt store.
+//
+// NOTE: Subscribed clients do not receive notice of this initialization.
+func (store *networkResultStore) InitAttempt(attemptID uint64) error {
+
+	// We get a mutex for this attempt ID. This is needed to ensure
+	// consistency between the database state and the subscribers in case
+	// of concurrent calls.
+	store.attemptIDMtx.Lock(attemptID)
+	defer store.attemptIDMtx.Unlock(attemptID)
+
+	// Check if any attempt by this ID is already initialized or whether a
+	// a result for the attempt exists in the store.
+	var existingResult *networkResult
+	err := kvdb.View(store.backend, func(tx kvdb.RTx) error {
+		var err error
+		existingResult, err = fetchResult(tx, attemptID)
+		if err != nil && !errors.Is(err, ErrPaymentIDNotFound) {
+			return err
+		}
+		return nil
+	}, func() {
+		existingResult = nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// If the result is already in-progress, return an error indicating that
+	// the attempt already exists.
+	if existingResult != nil {
+		log.Warnf("Already initialized attempt for ID=%v", attemptID)
+
+		return ErrPaymentIDAlreadyExists
+	}
+
+	// Create an empty networkResult to serve as place holder until a result
+	// from the network is received.
+	inProgressResult := &networkResult{
+		msg:          &lnwire.PendingNetworkResult{},
+		unencrypted:  true,
+		isResolution: false,
+	}
+
+	var b bytes.Buffer
+	if err := serializeNetworkResult(&b, inProgressResult); err != nil {
+		return err
+	}
+
+	var attemptIDBytes [8]byte
+	binary.BigEndian.PutUint64(attemptIDBytes[:], attemptID)
+
+	// Mark an attempt with this ID as having been seen. No network result
+	// is available yet.
+	//
+	// NOTE: Subscribed clients expecting to block until a network result is
+	// available must not be notified of this initialization.
+	err = kvdb.Batch(store.backend, func(tx kvdb.RwTx) error {
+		networkResults, err := tx.CreateTopLevelBucket(
+			networkResultStoreBucketKey,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Store the in-progress result.
+		return networkResults.Put(attemptIDBytes[:], b.Bytes())
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("Initialized attempt for local payment with attemptID=%v",
+		attemptID)
+
+	return nil
+}
+
 // storeResult stores the networkResult for the given attemptID, and notifies
 // any subscribers.
 func (store *networkResultStore) StoreResult(attemptID uint64,

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -118,7 +118,7 @@ func TestNetworkResultStore(t *testing.T) {
 	// Subscribe to 2 of them.
 	var subs []<-chan *networkResult
 	for i := uint64(0); i < 2; i++ {
-		sub, err := store.subscribeResult(i)
+		sub, err := store.SubscribeResult(i)
 		if err != nil {
 			t.Fatalf("unable to subscribe: %v", err)
 		}
@@ -127,7 +127,7 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Store three of them.
 	for i := uint64(0); i < 3; i++ {
-		err := store.storeResult(i, results[i])
+		err := store.StoreResult(i, results[i])
 		if err != nil {
 			t.Fatalf("unable to store result: %v", err)
 		}
@@ -144,7 +144,7 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Let the third one subscribe now. THe result should be received
 	// immediately.
-	sub, err := store.subscribeResult(2)
+	sub, err := store.SubscribeResult(2)
 	require.NoError(t, err, "unable to subscribe")
 	select {
 	case <-sub:
@@ -154,22 +154,22 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Try fetching the result directly for the non-stored one. This should
 	// fail.
-	_, err = store.getResult(3)
+	_, err = store.GetResult(3)
 	if err != ErrPaymentIDNotFound {
 		t.Fatalf("expected ErrPaymentIDNotFound, got %v", err)
 	}
 
 	// Add the result and try again.
-	err = store.storeResult(3, results[3])
+	err = store.StoreResult(3, results[3])
 	require.NoError(t, err, "unable to store result")
 
-	_, err = store.getResult(3)
+	_, err = store.GetResult(3)
 	require.NoError(t, err, "unable to get result")
 
 	// Since we don't delete results from the store (yet), make sure we
 	// will get subscriptions for all of them.
 	for i := uint64(0); i < numResults; i++ {
-		sub, err := store.subscribeResult(i)
+		sub, err := store.SubscribeResult(i)
 		if err != nil {
 			t.Fatalf("unable to subscribe: %v", err)
 		}
@@ -187,12 +187,12 @@ func TestNetworkResultStore(t *testing.T) {
 		1: {},
 	}
 	// Finally, delete the result.
-	err = store.cleanStore(toKeep)
+	err = store.CleanStore(toKeep)
 	require.NoError(t, err)
 
 	// Payment IDs 0 and 1 should be found, 2 and 3 should be deleted.
 	for i := uint64(0); i < numResults; i++ {
-		_, err = store.getResult(i)
+		_, err = store.GetResult(i)
 		if i <= 1 {
 			require.NoError(t, err, "unable to get result")
 		}

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -200,4 +200,46 @@ func TestNetworkResultStore(t *testing.T) {
 			t.Fatalf("expected ErrPaymentIDNotFound, got %v", err)
 		}
 	}
+
+	t.Run("InitAttempt duplicate prevention", func(t *testing.T) {
+		var id uint64 = 100
+
+		// First initialization should succeed.
+		err := store.InitAttempt(id)
+		require.NoError(t, err, "unexpected InitAttempt failure")
+
+		// Second initialization should fail (already initialized).
+		// Try initializing an attempt with the same ID before a full
+		// settle or fail result is back from the network (simulated by
+		// StoreResult).
+		err = store.InitAttempt(id)
+		require.ErrorIs(t, err, ErrPaymentIDAlreadyExists,
+			"expected duplicate InitAttempt to fail")
+
+		// Store a result to simulate a full settle or fail HTLC result
+		// coming back from the network.
+		netResult := &networkResult{
+			msg:          &lnwire.UpdateFulfillHTLC{},
+			unencrypted:  true,
+			isResolution: true,
+		}
+		err = store.StoreResult(id, netResult)
+		require.NoError(t, err, "unable to store result after init")
+
+		// Try InitAttempt again — still should fail even after a full
+		// result is back from the network.
+		err = store.InitAttempt(id)
+		require.ErrorIs(t, err, ErrPaymentIDAlreadyExists,
+			"expected InitAttempt to fail after result stored")
+
+		// Verify that ID can be re-used only after explicit deletion of
+		// attempts via CleanStore or a DeleteAttempts style method.
+		err = store.CleanStore(map[uint64]struct{}{})
+		require.NoError(t, err)
+
+		// Now InitAttempt should succeed again.
+		err = store.InitAttempt(id)
+		require.NoError(t, err, "InitAttempt should succeed after cleanup")
+
+	})
 }

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -541,12 +541,34 @@ func (s *Switch) CleanStore(keepPids map[uint64]struct{}) error {
 	return s.attemptStore.CleanStore(keepPids)
 }
 
-// SendHTLC is used by other subsystems which aren't belong to htlc switch
-// package in order to send the htlc update. The attemptID used MUST be unique
-// for this HTLC, and MUST be used only once, otherwise the switch might reject
-// it.
+// SendHTLC attempts to forward an HTLC to the given first hop using the
+// specified attempt ID. This is used by other subsystems to dispatch
+// a payment attempt.
+//
+// The Switch guarantees that only one HTLC will be forwarded for a given
+// attemptID, and will return ErrDuplicateAdd for subsequent uses until the ID
+// is explicitly cleaned from the underlying attempt store.
+//
+// This method is safe to call from remote clients (via SendOnion) or by local
+// subsystems such as the ChannelRouter.
 func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 	htlc *lnwire.UpdateAddHTLC) error {
+
+	// Safety check to ensure that this attempt ID is not currently created
+	// within the result store.
+	err := s.attemptStore.InitAttempt(attemptID)
+	if err != nil {
+		if errors.Is(err, ErrPaymentIDAlreadyExists) {
+			log.Debugf("Attempt id=%v already exists", attemptID)
+
+			return ErrDuplicateAdd
+		}
+
+		log.Errorf("unable to initialize attempt id=%d: %v",
+			attemptID, err)
+
+		return err
+	}
 
 	// Generate and send new update packet, if error will be received on
 	// this stage it means that packet haven't left boundaries of our

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -256,12 +256,12 @@ type Switch struct {
 	// service was initialized with.
 	cfg *Config
 
-	// networkResults stores the results of payments initiated by the user.
+	// attemptStore stores the results of payments initiated by the user.
 	// The store is used to later look up the payments and notify the
 	// user of the result when they are complete. Each payment attempt
 	// should be given a unique integer ID when it is created, otherwise
 	// results might be overwritten.
-	networkResults *networkResultStore
+	attemptStore AttemptStore
 
 	// circuits is storage for payment circuits which are used to
 	// forward the settle/fail htlc updates back to the add htlc initiator.
@@ -381,7 +381,7 @@ func New(cfg Config, currentHeight uint32) (*Switch, error) {
 		interfaceIndex:    make(map[[33]byte]map[lnwire.ChannelID]ChannelLink),
 		pendingLinkIndex:  make(map[lnwire.ChannelID]ChannelLink),
 		linkStopIndex:     make(map[lnwire.ChannelID]chan struct{}),
-		networkResults:    newNetworkResultStore(cfg.DB),
+		attemptStore:      newNetworkResultStore(cfg.DB),
 		htlcPlex:          make(chan *plexPacket),
 		chanCloseRequests: make(chan *ChanClose),
 		resolutionMsgs:    make(chan *resolutionMsg),
@@ -439,7 +439,7 @@ func (s *Switch) ProcessContractResolution(msg contractcourt.ResolutionMsg) erro
 // HasAttemptResult reads the network result store to fetch the specified
 // attempt. Returns true if the attempt result exists.
 func (s *Switch) HasAttemptResult(attemptID uint64) (bool, error) {
-	_, err := s.networkResults.getResult(attemptID)
+	_, err := s.attemptStore.GetResult(attemptID)
 	if err == nil {
 		return true, nil
 	}
@@ -476,7 +476,7 @@ func (s *Switch) GetAttemptResult(attemptID uint64, paymentHash lntypes.Hash,
 	// is already available.
 	// Assumption: no one will add this attempt ID other than the caller.
 	if s.circuits.LookupCircuit(inKey) == nil {
-		res, err := s.networkResults.getResult(attemptID)
+		res, err := s.attemptStore.GetResult(attemptID)
 		if err != nil {
 			return nil, err
 		}
@@ -486,7 +486,7 @@ func (s *Switch) GetAttemptResult(attemptID uint64, paymentHash lntypes.Hash,
 	} else {
 		// The HTLC was committed to the circuits, subscribe for a
 		// result.
-		nChan, err = s.networkResults.subscribeResult(attemptID)
+		nChan, err = s.attemptStore.SubscribeResult(attemptID)
 		if err != nil {
 			return nil, err
 		}
@@ -538,7 +538,7 @@ func (s *Switch) GetAttemptResult(attemptID uint64, paymentHash lntypes.Hash,
 // preiodically to let the switch clean up payment results that we have
 // handled.
 func (s *Switch) CleanStore(keepPids map[uint64]struct{}) error {
-	return s.networkResults.cleanStore(keepPids)
+	return s.attemptStore.CleanStore(keepPids)
 }
 
 // SendHTLC is used by other subsystems which aren't belong to htlc switch
@@ -965,7 +965,7 @@ func (s *Switch) handleLocalResponse(pkt *htlcPacket) {
 
 	// Store the result to the db. This will also notify subscribers about
 	// the result.
-	if err := s.networkResults.storeResult(attemptID, n); err != nil {
+	if err := s.attemptStore.StoreResult(attemptID, n); err != nil {
 		log.Errorf("Unable to store attempt result for pid=%v: %v",
 			attemptID, err)
 		return

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -3107,7 +3107,7 @@ func TestSwitchGetAttemptResult(t *testing.T) {
 		isResolution: true,
 	}
 
-	err = s.networkResults.storeResult(paymentID, n)
+	err = s.attemptStore.StoreResult(paymentID, n)
 	require.NoError(t, err, "unable to store result")
 
 	// The result should be available.

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -5555,3 +5555,108 @@ func testSwitchAliasInterceptFail(t *testing.T, zeroConf bool) {
 
 	require.NoError(t, interceptSwitch.Stop())
 }
+
+// TestSwitchDuplicateAttemptPrevention validates the behavior of the Switch and
+// its underlying stores with respect to re-use of HTLC attempt ID. We expect
+// the Switch to guarantee that only one HTLC will be forwarded for a given
+// attemptID until the ID is explicitly cleaned from the underlying attempt
+// store.
+func TestSwitchDuplicateAttemptPrevention(t *testing.T) {
+	t.Parallel()
+
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil, testDefaultDelta)
+	require.NoError(t, err)
+
+	s, err := initSwitchWithTempDB(t, testStartingHeight)
+	require.NoError(t, err)
+	require.NoError(t, s.Start())
+	defer s.Stop()
+
+	chanID, _, aliceChanID, _ := genIDs()
+
+	aliceLink := newMockChannelLink(
+		s, chanID, aliceChanID, emptyScid,
+		alicePeer, true, false, false, false,
+	)
+	require.NoError(t, s.AddLink(aliceLink))
+
+	preimage, err := genPreimage()
+	require.NoError(t, err)
+	rhash := sha256.Sum256(preimage[:])
+	attemptID := uint64(123)
+
+	update := &lnwire.UpdateAddHTLC{
+		PaymentHash: rhash,
+		Amount:      lnwire.NewMSatFromSatoshis(1000),
+		ChanID:      chanID,
+	}
+
+	// --- Subtest 1: Duplicate in-flight attempt ---
+	err = s.SendHTLC(aliceLink.ShortChanID(), attemptID, update)
+	require.NoError(t, err, "expected first SendHTLC to succeed")
+
+	err = s.SendHTLC(aliceLink.ShortChanID(), attemptID, update)
+	require.ErrorIs(t, err, ErrDuplicateAdd, "expected duplicate attempt to fail while in-flight")
+
+	// --- Subtest 2: Duplicate after result rejected ---
+
+	// Launch a routine to await the result of the HTLC attempt.
+	errChan := make(chan error, 1)
+	go func() {
+		resultChan, err := s.GetAttemptResult(
+			attemptID, rhash,
+			newMockDeobfuscator(),
+		)
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		result, ok := <-resultChan
+		if !ok {
+			errChan <- fmt.Errorf("result channel closed")
+			return
+		}
+		if result.Error != nil {
+			errChan <- result.Error
+			return
+		}
+		if result.Preimage != preimage {
+			errChan <- fmt.Errorf("preimage mismatch")
+			return
+		}
+		errChan <- nil
+	}()
+
+	select {
+	case pkt := <-aliceLink.packets:
+		require.NoError(t, aliceLink.completeCircuit(pkt))
+	case <-time.After(time.Second):
+		t.Fatal("packet not received")
+	}
+
+	// Send fulfillment packet.
+	settlePkt := &htlcPacket{
+		outgoingChanID: aliceLink.ShortChanID(),
+		outgoingHTLCID: 0,
+		htlc: &lnwire.UpdateFulfillHTLC{
+			PaymentPreimage: preimage,
+		},
+		amount: lnwire.NewMSatFromSatoshis(1000),
+	}
+	require.NoError(t, s.ForwardPackets(nil, settlePkt))
+
+	// The SendHTLC goroutine should complete successfully.
+	select {
+	case err := <-errChan:
+		require.NoError(t, err, "expected HTLC to complete successfully")
+	case <-time.After(time.Second):
+		t.Fatal("did not receive result")
+	}
+
+	// Attempt to reuse the attempt ID after the full settle or fail result
+	// is back from the network.
+	err = s.SendHTLC(aliceLink.ShortChanID(), attemptID, update)
+	require.ErrorIs(t, err, ErrDuplicateAdd, "expected reuse after result to fail")
+
+}

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -67,6 +67,11 @@ const (
 	MsgChannelUpdate2                      = 271
 	MsgKickoffSig                          = 777
 
+	// MsgPendingNetworkResult is an internal message used by the Switch
+	// network result store as a place holder when initializing an HTLC
+	// attempt within the store. It will not be received from network peers.
+	MsgPendingNetworkResult = 0xffff
+
 	// MsgEnd defines the end of the official message range of the protocol.
 	// If a new message is added beyond this message, then this should be
 	// modified.
@@ -195,6 +200,8 @@ func (t MessageType) String() string {
 		return "ChannelAnnouncement2"
 	case MsgChannelUpdate2:
 		return "ChannelUpdate2"
+	case MsgPendingNetworkResult:
+		return "PendingNetworkResult"
 	default:
 		return "<unknown>"
 	}
@@ -357,6 +364,8 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 		msg = &ChannelAnnouncement2{}
 	case MsgChannelUpdate2:
 		msg = &ChannelUpdate2{}
+	case MsgPendingNetworkResult:
+		msg = &PendingNetworkResult{}
 	default:
 		// If the message is not within our custom range and has not
 		// specifically been overridden, return an unknown message.

--- a/lnwire/network_result.go
+++ b/lnwire/network_result.go
@@ -1,0 +1,32 @@
+package lnwire
+
+import (
+	"bytes"
+	"io"
+)
+
+// PendingNetworkResult is a dummy message that implements the Message
+// interface. It acts as a placeholder for the in-progress state of a locally
+// initiated HTLC payment attempt.
+type PendingNetworkResult struct{}
+
+// MsgType returns a default MessageType.
+func (e *PendingNetworkResult) MsgType() MessageType {
+	return MsgPendingNetworkResult
+}
+
+// Decode is a no-op decoder for the empty message. Since this is just a placeholder,
+// it doesn't actually decode any data.
+func (e *PendingNetworkResult) Decode(r io.Reader, pver uint32) error {
+	// No decoding necessary for an empty message.
+	return nil
+}
+
+// Encode is a no-op encoder for the empty message. Since this is just a placeholder,
+// it doesn't actually encode any data.
+func (e *PendingNetworkResult) Encode(w *bytes.Buffer, pver uint32) error {
+	// No encoding necessary for an empty message. The message type will
+	// be encoded by the library and is enough to distinguish this from
+	// other messages.
+	return nil
+}

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -1110,6 +1110,24 @@ func (p *paymentLifecycle) patchLegacyPaymentHash(
 // reloadInflightAttempts is called when the payment lifecycle is resumed after
 // a restart. It reloads all inflight attempts from the control tower and
 // collects the results of the attempts that have been sent before.
+//
+// For each in-flight attempt, we defensively try to dispatch the attempt. This
+// serves to reassert delivery of the HTLC to the Switch, resolving any
+// ambiguity about whether the original dispatch succeeded.
+//
+// In monolithic deployments (Router and Switch in the same process), this is
+// mostly harmless. If the attempt was already handed off to the Switch before
+// shutdown, the Switch will return ErrDuplicateAdd and we proceed to track
+// the result as normal. If the attempt was not yet sent, this ensures it
+// is delivered now.
+//
+// In remote or modular deployments, this retry becomes essential. The Router
+// (i.e., the HTLC lifecycle manager) and Switch may run in separate processes,
+// possibly on different machines. If the Router crashed or lost connectivity
+// after registering the attempt locally but before the HTLC was acknowledged
+// by the Switch, we may not know whether the attempt was successfully sent.
+// Because SendHTLC is now duplicate-safe, we can retry safely until we receive
+// a definitive response.
 func (p *paymentLifecycle) reloadInflightAttempts() (DBMPPayment, error) {
 	payment, err := p.router.cfg.Control.FetchPayment(p.identifier)
 	if err != nil {
@@ -1126,10 +1144,103 @@ func (p *paymentLifecycle) reloadInflightAttempts() (DBMPPayment, error) {
 		// it's a legacy payment.
 		a = p.patchLegacyPaymentHash(a)
 
+		// Re-dispatch the HTLC to resolve any ambiguity about delivery
+		// status. This is safe to do whether router and htlc dispatcher
+		// run together or separately due to duplicate protection in
+		// SendHTLC.
+		err := p.retrySendHTLC(&a)
+		if err != nil && !errors.Is(err, htlcswitch.ErrDuplicateAdd) {
+			log.Warnf("Retrying HTLC %v for payment %v failed: %v",
+				a.AttemptID, p.identifier, err)
+			continue
+		}
+
+		// Only track the result if the HTLC is confirmed in-flight.
 		p.resultCollector(&a)
 	}
 
 	return payment, nil
+}
+
+// retrySendHTLC attempts to (re)dispatch an HTLC for a previously registered
+// attempt. This is typically invoked when resuming the payment lifecycle after
+// a restart.
+//
+// In monolithic deployments (Router and Switch in the same process), this call
+// is mostly defensive. Either the HTLC was already sent before shutdown and
+// will result in ErrDuplicateAdd, or it was never sent and will now be
+// successfully dispatched.
+//
+// In remote Router deployments (Router and Switch in separate processes),
+// this call becomes essential for resolving ambiguity. The Router may have
+// crashed or lost connectivity after registering the attempt locally but before
+// confirming that the Switch received and persisted it. Since SendHTLC is
+// now duplicate-safe (via InitAttempt), it's safe to retry until a definitive
+// acknowledgment is returned.
+//
+// Dispatching may succeed here even though the attempt was previously marked
+// in-flight. This occurs if the Router registered the attempt in the control
+// tower, but the daemon exited or crashed before the HTLC was successfully
+// handed off to and persisted by the Switch.
+func (p *paymentLifecycle) retrySendHTLC(attempt *channeldb.HTLCAttempt) error {
+	log.Infof("Retrying HTLC attempt %v for payment %v",
+		attempt.AttemptID, p.identifier)
+
+	rt := attempt.Route
+	firstHop := lnwire.NewShortChanIDFromInt(rt.Hops[0].ChannelID)
+
+	htlcAdd := &lnwire.UpdateAddHTLC{
+		Amount:        rt.FirstHopAmount.Val.Int(),
+		Expiry:        rt.TotalTimeLock,
+		PaymentHash:   *attempt.Hash,
+		CustomRecords: rt.FirstHopWireCustomRecords,
+	}
+
+	onionBlob, err := attempt.OnionBlob()
+	if err != nil {
+		log.Errorf("Failed to retrieve onion blob: attempt=%d in "+
+			"payment=%v, err=%v", attempt.AttemptID, p.identifier,
+			err)
+
+		return err
+	}
+	htlcAdd.OnionBlob = onionBlob
+
+	err = p.router.cfg.Payer.SendHTLC(firstHop, attempt.AttemptID, htlcAdd)
+
+	switch {
+	case err == nil:
+		// This can occur if the attempt was marked in-flight by the
+		// router's payment life-cycle manager, but the process exited
+		// before the Switch persisted the HTLC.
+		log.Debug("Dispatched HTLC for previously initiated but unsent "+
+			"attemptID=%d", attempt.AttemptID)
+
+	case errors.Is(err, htlcswitch.ErrDuplicateAdd):
+		// This is the expected case for the vast majority of attempts
+		// when the router and Switch run in the same process. Since
+		// HTLC dispatch and persistence are tightly coupled in that
+		// model, an attempt marked as in-flight in the control tower
+		// was almost certainly handed off to the Switch before shutdown.
+		//
+		// In remote router deployments, this case indicates that the
+		// HTLC was already delivered to the Switch during a prior
+		// invocation of SendHTLC, but the router crashed or disconnected
+		// before receiving confirmation. Because SendHTLC is now
+		// duplicate-safe, we can safely retry until we receive a
+		// definitive response. The duplicate error here tells us that
+		// the HTLC is already tracked by the Switch and we should
+		// proceed to wait for its result.
+		log.Infof("An HTLC for attemptID=%v was already dispatched, "+
+			"tracking result...", attempt.AttemptID)
+
+	default:
+		log.Warnf("Unexpected dispatch error for attemptID=%v: %v",
+			attempt.AttemptID, err)
+	}
+
+	// Return the actual error (nil, ErrDuplicateAdd, or other).
+	return err
 }
 
 // reloadPayment returns the latest payment found in the db (control tower).


### PR DESCRIPTION
## Background
### Ambiguity in gRPC and Network Calls

When a remote router's `SendOnion` call fails with a network error (like `gRPC codes.Unavailable` or a timeout), we are in an ambiguous state. From the rpc client's perspective, one of three things happened:

1.  **The request never reached the server.** The network dropped the packet on the way there.
2.  **The request reached the server, the server processed it successfully, but the *response* was lost on the way back.**
3.  **The request reached the server, and the server crashed before it could process it.**

A network error **does not and cannot distinguish between these scenarios.** It only informs that the communication channel broke. It provides zero information about the state of the server.

Because we cannot distinguish between scenario 1 (safe to retry) and scenario 2 (disastrous to retry without an idempotency check), we **must assume the worst-case scenario**: that the server *did* receive and process your request. 

-   **At-Least-Once Delivery:** "Retry until you get an ACK." This is our chosen pattern. We guarantee the dispatcher (Switch or Switch RPC server) will _eventually_ process the request, but we accept that it might receive the request multiple times if our acknowledgement is lost.

## Change Description

This PR attempts to generalize the _**ChannelRouter**_ type such that it can be used  both as it always has been and by a remote router which submits onions for forwarding via RPC. To do this, we must analyze the contract offered by the _**PaymentAttemptDispatcher**_ interface connecting Router and Switch.

When **_SendHTLC_** returns, it is expected that the Router know, without any uncertainty, whether the HTLC is in-flight (no error) or that it is neither in flight nor will it ever be in flight. As described above, this is tricky to guarantee when the communication happens over a network. 

This change allows for the resolving of any ambiguity in the status of an HTLC in the case where the **_ChannelRouter_** and **_Switch_** run in separate processes and communicate over the network. Instead we allow the server to resolve any uncertainty by calling **_SendHTLC_** while resuming a payment prior to attempting to track the result. If the HTLC was successfully received by the remote Switch, then the Router will receive a duplicate HTLC error and can proceed to tracking the attempt result like normal.

This router startup modification appears un-interesting, and even _unnecessary_, in the default case where _**ChannelRouter**_ and _**Switch**_ run together in a single _**lnd**_ binary, but becomes more important for correctness when the _**Router**_ and _**Switch**_ run in separate processes and communicate via RPC.


## Alternatives

- The router and switch should probably take care to leverage some ideas around reliable communication such as retries, _acknowledgements_ and idempotence to ensure at most once delivery and request processing of a given HTLC attempt. This will permit a greater degree of robustness in the handoff of the HTLC attempt dispatch request across the process boundary while limiting any potential for duplicate attempts.
- One alternative would be to upgrade the router to add _**explicit**_ attempt dispatch acknowledgement. The router would first **_RegisterAttempt_**, then **_SendHTLC_**, and upon success, make a final **_AckAttempt_** call to the _**ControlTower**_ (payments db). This would eliminate ambiguity for the vast majority of in-flight HTLCs, allowing the router to proceed directly to tracking their results on startup _without_ a defensive re-dispatch.
- Implicit dispatch acknowledgement _cannot_ survive restarts, hence: In the absence of persistent acknowledgements of HTLC dispatch (eg: **_AckAttempt_** on **_ControlTower_**), the router likely also needs to defensively retry HTLC dispatch during attempt resumption on startup.