### PR TITLE
htlcswitch: most significant byte namespacing in result store

### DIFF
--- a/docs/release-notes/release-notes-0.20.0.md
+++ b/docs/release-notes/release-notes-0.20.0.md
@@ -93,6 +93,12 @@ circuit. The indices are only available for forwarding events saved after v0.20.
     * [10](https://github.com/lightningnetwork/lnd/pull/9971)
     * [11](https://github.com/lightningnetwork/lnd/pull/9972)
 
+* Move htlc attempt ID generation (`NextAttemptID`) method to the
+ `PaymentAttemptDispatcher` interface. This shifts the responsibility of
+  generating unique htlc attempt IDs from the ChannelRouter (payement life-cycle
+  manager) to the HTLCSwitch (switchrpc server). Allocating IDs centrally from
+  within the Switch prepares the daemon for multi-router support.
+
 ## RPC Updates
 * Previously the `RoutingPolicy` would return the inbound fee record in its
   `CustomRecords` field, which is duplicated info as it's already presented in

--- a/htlcswitch/sequencer.go
+++ b/htlcswitch/sequencer.go
@@ -11,10 +11,10 @@ import (
 // allocated for each write to disk made by the sequencer.
 const defaultSequenceBatchSize = 1000
 
-// DefaultAttemptStoreNamespace is the name of the default attempt ID namespace.
+// DefaultAttemptIDNamespace is the name of the default attempt ID namespace.
 // This is used as the sub-bucket key within the top level DB bucket to store
 // mission control results.
-var DefaultAttemptStoreNamespace = []byte{}
+var DefaultAttemptIDNamespace = []byte{}
 
 // Sequencer emits sequence numbers for locally initiated HTLCs. These are
 // only used internally for tracking pending payments, however they must be


### PR DESCRIPTION
## Change Description
... talk about ID space separation...
