### PR TITLE
Switch attempt store handle orphans

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -37,6 +37,15 @@
 
 ## Breaking Changes
 
+* Added [duplicate safety to `switch.SendHTLC`](https://github.com/lightningnetwork/lnd/pull/10049). This method will no longer 
+  forward an onion with the same attempt ID twice without the result for a given
+  ID having been cleaned from the network result store. This ensures "at most
+  once" delivery and request processing of a given HTLC attempt, allowing a
+  remote router or rpc client to safely retry htlc dispatch requests without
+  creating duplicate attempts. This extends the more narrow duplicate safety
+  already provided by the Switch’s `CircuitMap`.
+
+
 ## Performance Improvements
 
 ## Deprecations

--- a/htlcswitch/cleanup_test.go
+++ b/htlcswitch/cleanup_test.go
@@ -1,0 +1,212 @@
+package htlcswitch
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSwitchSendHTLCSyncRollback tests that if SendHTLC fails after the
+// attempt has been initialized, a final failure result is synchronously
+// stored in the attempt store. This is critical to prevent callers of
+// GetAttemptResult from hanging indefinitely.
+func TestSwitchSendHTLCSyncRollback(t *testing.T) {
+	t.Parallel()
+
+	// Create a new switch with a persistent attempt store. We can use the
+	// unexported helper from switch_test.go since we are in the same
+	// package.
+	s, err := initSwitchWithTempDB(t, 0)
+	require.NoError(t, err)
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { require.NoError(t, s.Stop()) })
+
+	// We will attempt to send an HTLC to a non-existent channel. This will
+	// cause SendHTLC to fail after the attempt has been initialized.
+	invalidScid := lnwire.NewShortChanIDFromInt(123)
+	attemptID := uint64(1)
+	htlc := &lnwire.UpdateAddHTLC{}
+
+	// The call to SendHTLC should fail.
+	err = s.SendHTLC(invalidScid, attemptID, htlc)
+	require.Error(t, err)
+
+	// Now, we check the attempt store for the result. We expect to find a
+	// final FAILED result, not ErrPaymentIDNotFound or
+	// ErrAttemptResultNotAvailable.
+	result, err := s.attemptStore.GetResult(attemptID)
+	require.NoError(t, err, "expected to find a final result")
+	require.NotNil(t, result, "result should not be nil")
+
+	// The result should be a failure message.
+	failMsg, ok := result.msg.(*lnwire.UpdateFailHTLC)
+	require.True(t, ok, "expected an UpdateFailHTLC message")
+
+	// Since this was a local failure, the reason should be an unencrypted
+	// failure message that we can decode.
+	require.True(t, result.unencrypted, "expected unencrypted failure")
+	reason, err := lnwire.DecodeFailure(
+		bytes.NewReader(failMsg.Reason), 0,
+	)
+	require.NoError(t, err, "unable to decode failure reason")
+
+	// We expect the specific failure to be an UnknownNextPeer error, since
+	// that's what our SendHTLC call should have failed with.
+	_, ok = reason.(*lnwire.FailUnknownNextPeer)
+	require.True(t, ok, "expected unknown next peer failure")
+
+	// Now, we'll call GetAttemptResult. Since the synchronous rollback
+	// should have already stored a final result, we expect this call to
+	// return immediately with a failed result.
+	resChan, err := s.GetAttemptResult(attemptID, lntypes.Hash{}, nil)
+	require.NoError(t, err, "GetAttemptResult should not fail")
+
+	// We expect to receive a result immediately.
+	select {
+	case result := <-resChan:
+		// The result should be a failure.
+		require.Error(t, result.Error, "expected a failed result")
+
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("GetAttemptResult should have returned immediately")
+	}
+}
+
+// TestSwitchGetAttemptResultHangsOnOrphanedAttempt tests that a caller to
+// GetAttemptResult will hang if an attempt is orphaned in the pending state,
+// and that the synchronous rollback (`failAttempt`) fixes this.
+func TestSwitchGetAttemptResultHangsOnOrphanedAttempt(t *testing.T) {
+	t.Parallel()
+
+	s, err := initSwitchWithTempDB(t, 0)
+	require.NoError(t, err)
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { require.NoError(t, s.Stop()) })
+
+	// Manually initialize an attempt in the store. This simulates the "bad"
+	// state where an attempt is pending but has no corresponding circuit,
+	// which our SendHTLC changes are designed to prevent.
+	attemptID := uint64(1)
+	err = s.attemptStore.InitAttempt(attemptID)
+	require.NoError(t, err, "unable to initialize attempt")
+
+	// Now, call GetAttemptResult in a goroutine. This function returns a
+	// channel that will deliver the result.
+	resultCheckChan := make(chan *PaymentResult)
+	errChan := make(chan error)
+	go func() {
+		resChan, err := s.GetAttemptResult(
+			attemptID, lntypes.Hash{}, nil,
+		)
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		// Wait for the result to be delivered on the returned
+		// channel. We add a timeout here to prevent the test
+		// goroutine from leaking if something goes wrong.
+		select {
+		case result := <-resChan:
+			// Once we receive the result, we forward it to our
+			// test's result channel.
+			resultCheckChan <- result
+		case <-time.After(5 * time.Second):
+			errChan <- errors.New("goroutine timed out")
+		}
+	}()
+
+	// We expect the call to hang. We'll use a timeout to verify that no
+	// result is received.
+	select {
+	case <-resultCheckChan:
+		t.Fatalf("received result unexpectedly, should have hung")
+	case err := <-errChan:
+		t.Fatalf("received error unexpectedly: %v", err)
+	case <-time.After(100 * time.Millisecond):
+		// This is the expected path, the call has "hung" for 100ms.
+	}
+
+	// Now, simulate the fix by manually calling failAttempt. This is what
+	// SendHTLC now does synchronously on failure.
+	s.failAttempt(attemptID, NewLinkError(&lnwire.FailTemporaryNodeFailure{}))
+
+	// The goroutine should now un-hang and deliver the final failed result.
+	select {
+	case result := <-resultCheckChan:
+		// We expect a result with an error, indicating failure.
+		require.Error(t, result.Error, "expected a failed result")
+	case err := <-errChan:
+		t.Fatalf("received unexpected error: %v", err)
+	case <-time.After(1 * time.Second):
+		t.Fatalf("did not receive result after manual failure")
+	}
+}
+
+// TestSwitchOrphanedAttemptCleanup tests that the switch's startup procedure
+// will correctly identify and clean up any orphaned attempts left in the
+// 'pending' state. This can occur if the sync rollback of the initialization
+// fails or we crash in between attempt initialization and commiting the attempt
+// to the circuit map.
+func TestSwitchOrphanedAttemptCleanup(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary database path that will persist across restarts.
+	tempPath := t.TempDir()
+
+	// First, we'll create a database and a switch instance.
+	cdb1 := channeldb.OpenForTesting(t, tempPath)
+	s1, err := initSwitchWithDB(0, cdb1)
+	require.NoError(t, err)
+	require.NoError(t, s1.Start())
+
+	// Manually initialize an attempt to simulate the state of the database
+	// if the node crashed after InitAttempt.
+	attemptID := uint64(1)
+	err = s1.attemptStore.InitAttempt(attemptID)
+	require.NoError(t, err, "unable to initialize attempt")
+
+	// We must stop the switch and close its database to ensure the state
+	// is flushed to disk at tempPath.
+	require.NoError(t, s1.Stop())
+	require.NoError(t, cdb1.Close())
+
+	// Now, we'll create a new database instance from the same path and a
+	// new switch. This simulates a node restart.
+	cdb2 := channeldb.OpenForTesting(t, tempPath)
+	t.Cleanup(func() { cdb2.Close() })
+
+	s2, err := initSwitchWithDB(0, cdb2)
+	require.NoError(t, err)
+	require.NoError(t, s2.Start())
+	t.Cleanup(func() { require.NoError(t, s2.Stop()) })
+
+	// After startup, we query the store for our orphaned attempt ID. We
+	// expect to find a final FAILED result, as the janitor should have
+	// cleaned it up.
+	result, err := s2.attemptStore.GetResult(attemptID)
+	require.NoError(t, err, "expected to find a final result")
+	require.NotNil(t, result, "result should not be nil")
+
+	// The result should be a failure message.
+	failMsg, ok := result.msg.(*lnwire.UpdateFailHTLC)
+	require.True(t, ok, "expected an UpdateFailHTLC message")
+
+	// The janitor uses a generic failure reason, since it cannot know the
+	// original cause.
+	require.True(t, result.unencrypted, "expected unencrypted failure")
+	reason, err := lnwire.DecodeFailure(
+		bytes.NewReader(failMsg.Reason), 0,
+	)
+	require.NoError(t, err, "unable to decode failure reason")
+
+	// We expect the specific failure to be a FailTemporaryNodeFailure.
+	_, ok = reason.(*lnwire.FailTemporaryNodeFailure)
+	require.True(t, ok, "expected temporary node failure")
+}

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -530,3 +530,27 @@ type AuxTrafficShaper interface {
 	// meaning that it's from a custom channel.
 	IsCustomHTLC(htlcRecords lnwire.CustomRecords) bool
 }
+
+// AttemptStore defines the interface for storing and managing the results
+// of HTLC payment attempts. It is designed to support both local and remote
+// lifecycle controllers, allowing full control over result storage and cleanup.
+type AttemptStore interface {
+	// StoreResult stores the result of a given payment attempt (identified
+	// by attemptID). This will be called when a result is received from the
+	// network.
+	StoreResult(attemptID uint64, result *networkResult) error
+
+	// GetResult returns the network result for the specified attempt ID if
+	// it's available.
+	GetResult(attemptID uint64) (*networkResult, error)
+
+	// SubscribeResult subscribes to be notified when a result for a
+	// specific attempt ID becomes available. It returns a channel that will
+	// receive the result.
+	SubscribeResult(attemptID uint64) (<-chan *networkResult, error)
+
+	// CleanStore removes all attempt results from the store except for
+	// those listed in the keepPids map. This allows for a "delete all
+	// except" approach to cleanup.
+	CleanStore(keepPids map[uint64]struct{}) error
+}

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -547,10 +547,10 @@ type AttemptStore interface {
 	// GetResult returns the network result for the specified attempt ID if
 	// it's available.
 	//
-	// NOTE: This method will return ErrPaymentIDNotFound for attempts that
-	// have been initialized via InitAttempt but for which a final result
-	// (settle/fail) has not yet been stored. This is to preserve legacy
-	// behavior.
+	// NOTE: This method will return ErrAttemptResultNotAvailable for attempts
+	// that have been initialized via InitAttempt but for which a final result
+	// (settle/fail) has not yet been stored. ErrPaymentIDNotFound is returned
+	// for attempts that are unknown.
 	GetResult(attemptID uint64) (*networkResult, error)
 
 	// SubscribeResult subscribes to be notified when a result for a

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -566,4 +566,8 @@ type AttemptStore interface {
 	// those listed in the keepPids map. This allows for a "delete all
 	// except" approach to cleanup.
 	CleanStore(keepPids map[uint64]struct{}) error
+
+	// FetchPendingAttempts returns a list of all attempt IDs that are
+	// currently in the pending state.
+	FetchPendingAttempts() ([]uint64, error)
 }

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -542,11 +542,20 @@ type AttemptStore interface {
 
 	// GetResult returns the network result for the specified attempt ID if
 	// it's available.
+	//
+	// NOTE: This method will return ErrPaymentIDNotFound for attempts that
+	// have been initialized via InitAttempt but for which a final result
+	// (settle/fail) has not yet been stored. This is to preserve legacy
+	// behavior.
 	GetResult(attemptID uint64) (*networkResult, error)
 
 	// SubscribeResult subscribes to be notified when a result for a
 	// specific attempt ID becomes available. It returns a channel that will
 	// receive the result.
+	//
+	// NOTE: The returned channel will only receive a value for attempts that
+	// have a final result (settle/fail). It will not be notified of the
+	// initial pending state created by InitAttempt.
 	SubscribeResult(attemptID uint64) (<-chan *networkResult, error)
 
 	// CleanStore removes all attempt results from the store except for

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -535,6 +535,10 @@ type AuxTrafficShaper interface {
 // of HTLC payment attempts. It is designed to support both local and remote
 // lifecycle controllers, allowing full control over result storage and cleanup.
 type AttemptStore interface {
+	// Initialize the payment attempt. This should be called before actually
+	// dispatching the HTLC to the network.
+	InitAttempt(attemptID uint64) error
+
 	// StoreResult stores the result of a given payment attempt (identified
 	// by attemptID). This will be called when a result is received from the
 	// network.

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -104,9 +104,9 @@ func newNetworkResultStore(db kvdb.Backend) *networkResultStore {
 	}
 }
 
-// storeResult stores the networkResult for the given attemptID, and notifies
+// StoreResult stores the networkResult for the given attemptID, and notifies
 // any subscribers.
-func (store *networkResultStore) storeResult(attemptID uint64,
+func (store *networkResultStore) StoreResult(attemptID uint64,
 	result *networkResult) error {
 
 	// We get a mutex for this attempt ID. This is needed to ensure
@@ -152,9 +152,9 @@ func (store *networkResultStore) storeResult(attemptID uint64,
 	return nil
 }
 
-// subscribeResult is used to get the HTLC attempt result for the given attempt
+// SubscribeResult is used to get the HTLC attempt result for the given attempt
 // ID.  It returns a channel on which the result will be delivered when ready.
-func (store *networkResultStore) subscribeResult(attemptID uint64) (
+func (store *networkResultStore) SubscribeResult(attemptID uint64) (
 	<-chan *networkResult, error) {
 
 	// We get a mutex for this payment ID. This is needed to ensure
@@ -214,7 +214,7 @@ func (store *networkResultStore) subscribeResult(attemptID uint64) (
 
 // getResult attempts to immediately fetch the result for the given pid from
 // the store. If no result is available, ErrPaymentIDNotFound is returned.
-func (store *networkResultStore) getResult(pid uint64) (
+func (store *networkResultStore) GetResult(pid uint64) (
 	*networkResult, error) {
 
 	var result *networkResult
@@ -253,12 +253,12 @@ func fetchResult(tx kvdb.RTx, pid uint64) (*networkResult, error) {
 	return deserializeNetworkResult(r)
 }
 
-// cleanStore removes all entries from the store, except the payment IDs given.
+// CleanStore removes all entries from the store, except the payment IDs given.
 // NOTE: Since every result not listed in the keep map will be deleted, care
 // should be taken to ensure no new payment attempts are being made
 // concurrently while this process is ongoing, as its result might end up being
 // deleted.
-func (store *networkResultStore) cleanStore(keep map[uint64]struct{}) error {
+func (store *networkResultStore) CleanStore(keep map[uint64]struct{}) error {
 	return kvdb.Update(store.backend, func(tx kvdb.RwTx) error {
 		networkResults, err := tx.CreateTopLevelBucket(
 			networkResultStoreBucketKey,

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -330,8 +330,6 @@ func (store *networkResultStore) SubscribeResult(attemptID uint64) (
 // entry is an initialization placeholder (e.g. created via InitAttempt),
 // ErrPaymentIDNotFound is returned to signal that the result is not yet
 // available.
-//
-// NOTE: This method does not currently acquire the result subscription mutex.
 func (store *networkResultStore) GetResult(pid uint64) (
 	*networkResult, error) {
 

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -420,3 +420,50 @@ func (store *networkResultStore) CleanStore(keep map[uint64]struct{}) error {
 		return nil
 	}, func() {})
 }
+
+// FetchPendingAttempts returns a list of all attempt IDs that are currently in
+// the pending state.
+func (store *networkResultStore) FetchPendingAttempts() ([]uint64, error) {
+	var pending []uint64
+	err := kvdb.View(store.backend, func(tx kvdb.RTx) error {
+		bucket := tx.ReadBucket(networkResultStoreBucketKey)
+		if bucket == nil {
+			return nil
+		}
+
+		return bucket.ForEach(func(k, v []byte) error {
+			// If the key is not 8 bytes, it's not a valid attempt
+			// ID.
+			if len(k) != 8 {
+				return nil
+			}
+
+			// Deserialize the result to check its type.
+			r := bytes.NewReader(v)
+			result, err := deserializeNetworkResult(r)
+			if err != nil {
+				// If we can't deserialize, we'll log it and
+				// continue.
+				log.Warnf("Unable to deserialize result for "+
+					"key %x: %v", k, err)
+				return nil
+			}
+
+			// If the result is a pending result, add the attempt
+			// ID to our list.
+			if result.msg.MsgType() == pendingHtlcMsgType {
+				attemptID := binary.BigEndian.Uint64(k)
+				pending = append(pending, attemptID)
+			}
+
+			return nil
+		})
+	}, func() {
+		pending = nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return pending, nil
+}

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -28,6 +28,12 @@ var (
 	ErrPaymentIDAlreadyExists = errors.New("paymentID already exists")
 )
 
+const (
+	// pendingHtlcMsgType is a custom message type used to represent a
+	// pending HTLC in the network result store.
+	pendingHtlcMsgType lnwire.MessageType = 32768
+)
+
 // PaymentResult wraps a decoded result received from the network after a
 // payment attempt was made. This is what is eventually handed to the router
 // for processing.
@@ -117,7 +123,7 @@ func (store *networkResultStore) StoreResult(attemptID uint64,
 
 	log.Debugf("Storing result for attemptID=%v", attemptID)
 
-	// Serialize the payment result.
+	// Handle finalized result (success or failure).
 	var b bytes.Buffer
 	if err := serializeNetworkResult(&b, result); err != nil {
 		return err
@@ -141,13 +147,16 @@ func (store *networkResultStore) StoreResult(attemptID uint64,
 	}
 
 	// Now that the result is stored in the database, we can notify any
-	// active subscribers.
-	store.resultsMtx.Lock()
-	for _, res := range store.results[attemptID] {
-		res <- result
+	// active subscribers - but only if this isn't an initialized attempt
+	// awaiting a settle/fail result from the network.
+	if result.msg.MsgType() != pendingHtlcMsgType {
+		store.resultsMtx.Lock()
+		for _, res := range store.results[attemptID] {
+			res <- result
+		}
+		delete(store.results, attemptID)
+		store.resultsMtx.Unlock()
 	}
-	delete(store.results, attemptID)
-	store.resultsMtx.Unlock()
 
 	return nil
 }
@@ -194,11 +203,21 @@ func (store *networkResultStore) SubscribeResult(attemptID uint64) (
 		return nil, err
 	}
 
-	// If the result was found, we can send it on the result channel
-	// imemdiately.
+	// If a result is back from the network, we can send it on the result
+	// channel immemdiately. If the result is still our initialized place
+	// holder, then treat it as not yet available.
 	if result != nil {
-		resultChan <- result
-		return resultChan, nil
+		if result.msg.MsgType() != pendingHtlcMsgType {
+			log.Debugf("Obtained full result for attemptID=%v",
+				attemptID)
+
+			resultChan <- result
+
+			return resultChan, nil
+		}
+
+		log.Debugf("Awaiting result (settle/fail) for attemptID=%v",
+			attemptID)
 	}
 
 	// Otherwise we store the result channel for when the result is
@@ -212,8 +231,13 @@ func (store *networkResultStore) SubscribeResult(attemptID uint64) (
 	return resultChan, nil
 }
 
-// getResult attempts to immediately fetch the result for the given pid from
-// the store. If no result is available, ErrPaymentIDNotFound is returned.
+// GetResult attempts to immediately fetch the *final* network result for the
+// given attempt ID from the store. If no result is available, or if the only
+// entry is an initialization placeholder (e.g. created via InitAttempt),
+// ErrPaymentIDNotFound is returned to signal that the result is not yet
+// available.
+//
+// NOTE: This method does not currently acquire the result subscription mutex.
 func (store *networkResultStore) GetResult(pid uint64) (
 	*networkResult, error) {
 
@@ -221,7 +245,18 @@ func (store *networkResultStore) GetResult(pid uint64) (
 	err := kvdb.View(store.backend, func(tx kvdb.RTx) error {
 		var err error
 		result, err = fetchResult(tx, pid)
-		return err
+		if err != nil {
+			return err
+		}
+
+		// If the attempt is still in-flight, treat it as not yet
+		// available to preserve existing expectation for the behavior
+		// of this method.
+		if result.msg.MsgType() == pendingHtlcMsgType {
+			return ErrPaymentIDNotFound
+		}
+
+		return nil
 	}, func() {
 		result = nil
 	})

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -26,6 +26,12 @@ var (
 	// ErrPaymentIDAlreadyExists is returned if we try to write a pending
 	// payment whose paymentID already exists.
 	ErrPaymentIDAlreadyExists = errors.New("paymentID already exists")
+
+	// ErrAttemptResultNotAvailable is returned if we try to get a result
+	// for a pending payment whose result is not yet available.
+	ErrAttemptResultNotAvailable = errors.New(
+		"attempt result not yet available",
+	)
 )
 
 const (
@@ -341,7 +347,7 @@ func (store *networkResultStore) GetResult(pid uint64) (
 		// available to preserve existing expectation for the behavior
 		// of this method.
 		if result.msg.MsgType() == pendingHtlcMsgType {
-			return ErrPaymentIDNotFound
+			return ErrAttemptResultNotAvailable
 		}
 
 		return nil

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -118,7 +118,7 @@ func TestNetworkResultStore(t *testing.T) {
 	// Subscribe to 2 of them.
 	var subs []<-chan *networkResult
 	for i := uint64(0); i < 2; i++ {
-		sub, err := store.subscribeResult(i)
+		sub, err := store.SubscribeResult(i)
 		if err != nil {
 			t.Fatalf("unable to subscribe: %v", err)
 		}
@@ -127,7 +127,7 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Store three of them.
 	for i := uint64(0); i < 3; i++ {
-		err := store.storeResult(i, results[i])
+		err := store.StoreResult(i, results[i])
 		if err != nil {
 			t.Fatalf("unable to store result: %v", err)
 		}
@@ -144,7 +144,7 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Let the third one subscribe now. THe result should be received
 	// immediately.
-	sub, err := store.subscribeResult(2)
+	sub, err := store.SubscribeResult(2)
 	require.NoError(t, err, "unable to subscribe")
 	select {
 	case <-sub:
@@ -154,22 +154,22 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Try fetching the result directly for the non-stored one. This should
 	// fail.
-	_, err = store.getResult(3)
+	_, err = store.GetResult(3)
 	if err != ErrPaymentIDNotFound {
 		t.Fatalf("expected ErrPaymentIDNotFound, got %v", err)
 	}
 
 	// Add the result and try again.
-	err = store.storeResult(3, results[3])
+	err = store.StoreResult(3, results[3])
 	require.NoError(t, err, "unable to store result")
 
-	_, err = store.getResult(3)
+	_, err = store.GetResult(3)
 	require.NoError(t, err, "unable to get result")
 
 	// Since we don't delete results from the store (yet), make sure we
 	// will get subscriptions for all of them.
 	for i := uint64(0); i < numResults; i++ {
-		sub, err := store.subscribeResult(i)
+		sub, err := store.SubscribeResult(i)
 		if err != nil {
 			t.Fatalf("unable to subscribe: %v", err)
 		}
@@ -187,12 +187,12 @@ func TestNetworkResultStore(t *testing.T) {
 		1: {},
 	}
 	// Finally, delete the result.
-	err = store.cleanStore(toKeep)
+	err = store.CleanStore(toKeep)
 	require.NoError(t, err)
 
 	// Payment IDs 0 and 1 should be found, 2 and 3 should be deleted.
 	for i := uint64(0); i < numResults; i++ {
-		_, err = store.getResult(i)
+		_, err = store.GetResult(i)
 		if i <= 1 {
 			require.NoError(t, err, "unable to get result")
 		}

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -204,9 +204,25 @@ func TestNetworkResultStore(t *testing.T) {
 	t.Run("InitAttempt duplicate prevention", func(t *testing.T) {
 		var id uint64 = 100
 
+		// Now, try fetching the result directly. We expect to observe
+		// ErrAttemptResultNotAvailable since it's initialized but not
+		// yet finalized.
+		_, err = store.GetResult(id)
+		require.ErrorIs(t, err, ErrPaymentIDNotFound,
+			"expected ErrAttemptResultNotAvailable for pending "+
+				"attempt")
+
 		// First initialization should succeed.
 		err := store.InitAttempt(id)
 		require.NoError(t, err, "unexpected InitAttempt failure")
+
+		// Now, try fetching the result directly. We expect to observe
+		// ErrAttemptResultNotAvailable since it's initialized but not
+		// yet finalized.
+		_, err = store.GetResult(id)
+		require.ErrorIs(t, err, ErrAttemptResultNotAvailable,
+			"expected ErrAttemptResultNotAvailable for pending "+
+				"attempt")
 
 		// Subscribe for the result following the initialization. No
 		// result should be received immediately as StoreResult has not

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -443,11 +443,16 @@ func (s *Switch) HasAttemptResult(attemptID uint64) (bool, error) {
 		return true, nil
 	}
 
-	if !errors.Is(err, ErrPaymentIDNotFound) {
-		return false, err
+	// If we have not heard of this attempt ID, or have dispatched the
+	// attempt but have not yet received the final (settle/fail) result,
+	// then we return a nil error.
+	if errors.Is(err, ErrPaymentIDNotFound) ||
+		errors.Is(err, ErrAttemptResultNotAvailable) {
+
+		return false, nil
 	}
 
-	return false, nil
+	return false, err
 }
 
 // GetAttemptResult returns the result of the HTLC attempt with the given
@@ -476,13 +481,29 @@ func (s *Switch) GetAttemptResult(attemptID uint64, paymentHash lntypes.Hash,
 	// Assumption: no one will add this attempt ID other than the caller.
 	if s.circuits.LookupCircuit(inKey) == nil {
 		res, err := s.attemptStore.GetResult(attemptID)
-		if err != nil {
+		switch {
+		// We have a final result, we can send it immediately.
+		case err == nil:
+			c := make(chan *networkResult, 1)
+			c <- res
+			nChan = c
+
+		// The attempt is known, but the result is not yet available,
+		// so we fall through to subscribe.
+		case errors.Is(err, ErrAttemptResultNotAvailable):
+			log.Debugf("Attempt %d known, but result not yet "+
+				"available. Subscribing for result.", attemptID)
+
+		// If the error is anything else, we return it to the caller.
+		default:
 			return nil, err
 		}
-		c := make(chan *networkResult, 1)
-		c <- res
-		nChan = c
-	} else {
+	}
+
+	// If nChan is still nil, it means we need to subscribe. This happens
+	// if the circuit was found, or if GetResult told us the result is not
+	// yet available.
+	if nChan == nil {
 		// The HTLC was committed to the circuits, subscribe for a
 		// result.
 		nChan, err = s.attemptStore.SubscribeResult(attemptID)

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -3106,7 +3106,7 @@ func TestSwitchGetAttemptResult(t *testing.T) {
 		isResolution: true,
 	}
 
-	err = s.networkResults.storeResult(paymentID, n)
+	err = s.attemptStore.StoreResult(paymentID, n)
 	require.NoError(t, err, "unable to store result")
 
 	// The result should be available.


### PR DESCRIPTION
## Change Description

As part of the long-term goal to support a remote `ChannelRouter` (via `switchrpc`), this change makes the `Switch.SendHTLC` method fully idempotent. This is critical for remote clients like `SendOnion`, which must be able to safely retry requests after network timeouts without risking duplicate payments or receiving misleading, state-dependent errors.

While the `CircuitMap` provides some duplicate protection, its lifecycle is too short for a robustly idempotent API. This change introduces a more durable mechanism anchored in the `AttemptStore`.

### The `InitAttempt`-First Architecture

The core of this change is the introduction of `s.attemptStore.InitAttempt(attemptID)` as the **very first action** in `SendHTLC`. This `InitAttempt`-first ordering is non-negotiable for true idempotency, as it ensures that any retried request will receive a stable `DUPLICATE` response, confirming the original request was processed.

### The Layered Defense Against the Atomicity Gap

However, this `InitAttempt`-first approach creates a deliberate **atomicity gap**: a window between durably recording the payment's intent (`InitAttempt`) and committing it to the forwarding engine (`CommitCircuits`). A runtime error or crash within this gap would leave an orphaned "pending" record, causing clients to hang indefinitely.

To safely manage this gap, a **two-layered defense** has been implemented:

1.  **Layer 1: Synchronous Rollback (`failAttempt`)**
    *   For any **runtime error** that occurs after `InitAttempt` but before the circuit is committed, a new `failAttempt` helper is immediately called.
    *   This function synchronously transitions the attempt's state in the database from `PENDING` to `FAILED` before `SendHTLC` even returns an error. This makes the operation appear atomic to clients and prevents deadlocks during normal operation.

2.  **Layer 2: Startup Cleanup (`cleanupOrphanedAttempts`)**
    *   To handle the case of a **node crash** within the atomicity gap, a janitor routine now runs once at startup.
    *   It scans the `AttemptStore` for any `PENDING` attempts and cross-references them with the `CircuitMap`. Any attempt without a corresponding live circuit is identified as an orphan and safely failed.

This layered approach, combined with the introduction of `ErrAttemptResultNotAvailable` to provide a truthful API for in-flight attempts, guarantees a robust, deadlock-free, and truly idempotent service for all clients (both local and remote).

Finally, `SendHTLC` has been refactored to use a `prepareHTLCDispatch` helper, which cleanly separates the pre-commitment logic and centralizes the error handling for the synchronous rollback, improving the code's robustness and readability.

## TODO
- Modify the **_ChannelRouter_** to call _**SendHTLC**_ defensively when resuming payments after a restart. This is now safe and robust due to the idempotency guarantees provided by this change.

## Steps to Test
- All existing `htlcswitch` package unit tests pass.
- A new, comprehensive test suite has been added in `htlcswitch/cleanup_test.go` to explicitly validate the layered defense strategy:
    - `TestSwitchSendHTLCSyncRollback`: Confirms that a runtime failure in `SendHTLC` correctly triggers the synchronous rollback and does not cause a hang.
    - `TestSwitchGetAttemptResultHangsOnOrphanedAttempt`: Provides a concrete, reproducible demonstration of the deadlock bug that this new architecture solves.
    - `TestSwitchOrphanedAttemptCleanup`: Verifies that the startup janitor correctly self-heals the switch's state by cleaning up an orphaned attempt left behind by a simulated crash.
