### PR TITLE
htlcswitch: add InitAttempt for idempotent external dispatch

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -39,6 +39,16 @@
   has been removed from the public key parsing methods, and proper mutex
   protection has been added to the cache access in `DisconnectBlockAtHeight`.
 
+- The `ChannelRouter`'s payment life-cycle management may subscribe for a result
+  of an attempt that was never actually dispatched if we crash after
+  `CommitCircuits` records the Switch's intent to forward but before the HTLC is
+  included in the commitment transaction of the outgoing link. This change also
+  introduces a new `cleanupOrphanedAttempts` procedure *within the Switch* that
+  runs on startup. This routine addresses this inconsistent or dangling circuit
+  state by finding any attempts that were left in a pending state after a node
+  crash and safely fails them, fixing a long-standing latent bug where local
+  payments could become permanently stuck.
+
 # New Features
 
 - Basic Support for [onion messaging forwarding](https://github.com/lightningnetwork/lnd/pull/9868) 
@@ -47,6 +57,17 @@
   serialization and deserialization logic for peer-to-peer communication.
 
 ## Functional Enhancements
+
+* Introduced a new `AttemptStore` interface within `htlcswitch`, and expanded
+  its `kvdb` implementation, `networkResultStore`. A new `InitAttempt` method,
+  which serves as a "durable write of intent" or "write-ahead log" to checkpoint
+  an attempt in a new `PENDING` state prior to dispatch, now provides the
+  foundational durable storage required for external tracking of the HTLC
+  attempt lifecycle. This is a preparatory step that enables a future
+  idempotent `switchrpc.SendOnion` RPC, which will offer "at most once"
+  processing of htlc dispatch requests for remote clients. Care was taken to
+  avoid modifications to the existing flows for dispatching local payments,
+  preserving the existing battle-tested logic.
 
 ## RPC Additions
 

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -554,6 +554,26 @@ type AttemptStore interface {
 	// network.
 	StoreResult(attemptID uint64, result *networkResult) error
 
+	// FailPendingAttempt transitions an initialized attempt from an
+	// initialized to a failed state and records the provided reason. This
+	// is the synchronous rollback mechanism for attempts that fail before
+	// being committed to the forwarding engine. It returns an error if the
+	// underlying storage fails.
+	FailPendingAttempt(attemptID uint64, reason *LinkError) error
+
+	// FetchPendingAttempts returns a list of all attempt IDs that are
+	// currently in the pending state.
+	//
+	// NOTE: This function is primarily used by the Switch's startup logic
+	// to identify and clean up internally orphaned payment attempts. These
+	// occur when an attempt is initialized via InitAttempt but a crash
+	// prevents its full dispatch to the network (e.g., between InitAttempt
+	// and CommitCircuits). By fetching these pending attempts, the Switch
+	// can transition their state to FAILED, preventing external callers
+	// from indefinitely hanging on GetAttemptResult for an un-dispatched
+	// attempt.
+	FetchPendingAttempts() ([]uint64, error)
+
 	// GetResult returns the network result for the specified attempt ID if
 	// it's available.
 	//

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -104,9 +104,9 @@ func newNetworkResultStore(db kvdb.Backend) *networkResultStore {
 	}
 }
 
-// storeResult stores the networkResult for the given attemptID, and notifies
+// StoreResult stores the networkResult for the given attemptID, and notifies
 // any subscribers.
-func (store *networkResultStore) storeResult(attemptID uint64,
+func (store *networkResultStore) StoreResult(attemptID uint64,
 	result *networkResult) error {
 
 	// We get a mutex for this attempt ID. This is needed to ensure
@@ -152,9 +152,9 @@ func (store *networkResultStore) storeResult(attemptID uint64,
 	return nil
 }
 
-// subscribeResult is used to get the HTLC attempt result for the given attempt
+// SubscribeResult is used to get the HTLC attempt result for the given attempt
 // ID.  It returns a channel on which the result will be delivered when ready.
-func (store *networkResultStore) subscribeResult(attemptID uint64) (
+func (store *networkResultStore) SubscribeResult(attemptID uint64) (
 	<-chan *networkResult, error) {
 
 	// We get a mutex for this payment ID. This is needed to ensure
@@ -214,7 +214,7 @@ func (store *networkResultStore) subscribeResult(attemptID uint64) (
 
 // getResult attempts to immediately fetch the result for the given pid from
 // the store. If no result is available, ErrPaymentIDNotFound is returned.
-func (store *networkResultStore) getResult(pid uint64) (
+func (store *networkResultStore) GetResult(pid uint64) (
 	*networkResult, error) {
 
 	var result *networkResult
@@ -253,12 +253,12 @@ func fetchResult(tx kvdb.RTx, pid uint64) (*networkResult, error) {
 	return deserializeNetworkResult(r)
 }
 
-// cleanStore removes all entries from the store, except the payment IDs given.
+// CleanStore removes all entries from the store, except the payment IDs given.
 // NOTE: Since every result not listed in the keep map will be deleted, care
 // should be taken to ensure no new payment attempts are being made
 // concurrently while this process is ongoing, as its result might end up being
 // deleted.
-func (store *networkResultStore) cleanStore(keep map[uint64]struct{}) error {
+func (store *networkResultStore) CleanStore(keep map[uint64]struct{}) error {
 	return kvdb.Update(store.backend, func(tx kvdb.RwTx) error {
 		networkResults, err := tx.CreateTopLevelBucket(
 			networkResultStoreBucketKey,

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -118,7 +118,7 @@ func TestNetworkResultStore(t *testing.T) {
 	// Subscribe to 2 of them.
 	var subs []<-chan *networkResult
 	for i := uint64(0); i < 2; i++ {
-		sub, err := store.subscribeResult(i)
+		sub, err := store.SubscribeResult(i)
 		if err != nil {
 			t.Fatalf("unable to subscribe: %v", err)
 		}
@@ -127,7 +127,7 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Store three of them.
 	for i := uint64(0); i < 3; i++ {
-		err := store.storeResult(i, results[i])
+		err := store.StoreResult(i, results[i])
 		if err != nil {
 			t.Fatalf("unable to store result: %v", err)
 		}
@@ -144,7 +144,7 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Let the third one subscribe now. THe result should be received
 	// immediately.
-	sub, err := store.subscribeResult(2)
+	sub, err := store.SubscribeResult(2)
 	require.NoError(t, err, "unable to subscribe")
 	select {
 	case <-sub:
@@ -154,22 +154,22 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Try fetching the result directly for the non-stored one. This should
 	// fail.
-	_, err = store.getResult(3)
+	_, err = store.GetResult(3)
 	if err != ErrPaymentIDNotFound {
 		t.Fatalf("expected ErrPaymentIDNotFound, got %v", err)
 	}
 
 	// Add the result and try again.
-	err = store.storeResult(3, results[3])
+	err = store.StoreResult(3, results[3])
 	require.NoError(t, err, "unable to store result")
 
-	_, err = store.getResult(3)
+	_, err = store.GetResult(3)
 	require.NoError(t, err, "unable to get result")
 
 	// Since we don't delete results from the store (yet), make sure we
 	// will get subscriptions for all of them.
 	for i := uint64(0); i < numResults; i++ {
-		sub, err := store.subscribeResult(i)
+		sub, err := store.SubscribeResult(i)
 		if err != nil {
 			t.Fatalf("unable to subscribe: %v", err)
 		}
@@ -187,12 +187,12 @@ func TestNetworkResultStore(t *testing.T) {
 		1: {},
 	}
 	// Finally, delete the result.
-	err = store.cleanStore(toKeep)
+	err = store.CleanStore(toKeep)
 	require.NoError(t, err)
 
 	// Payment IDs 0 and 1 should be found, 2 and 3 should be deleted.
 	for i := uint64(0); i < numResults; i++ {
-		_, err = store.getResult(i)
+		_, err = store.GetResult(i)
 		if i <= 1 {
 			require.NoError(t, err, "unable to get result")
 		}

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -3106,7 +3106,7 @@ func TestSwitchGetAttemptResult(t *testing.T) {
 		isResolution: true,
 	}
 
-	err = s.networkResults.storeResult(paymentID, n)
+	err = s.attemptStore.StoreResult(paymentID, n)
 	require.NoError(t, err, "unable to store result")
 
 	// The result should be available.


### PR DESCRIPTION
## Background
As part of a larger effort to support offloading path-finding and payment life-cycle management to an external entity, we are introducing a new `switchrpc` gRPC sub-server https://github.com/lightningnetwork/lnd/pull/9489. This will allow a remotely instantiated `ChannelRouter` or other RPC client to orchestrate payments across a set of remote `lnd` instances.

To safely support this, we need to prevent duplicate payment attempts and resulting unintentional loss of funds when using the forthcoming _**switchrpc**_ server and `SendOnion` RPC. The two primary categories of duplicate payment risk are:
1.  **Server-Side Logic Failure:** The `htlcswitch` fails to enforce "at-most-once" dispatch for a given `attemptID`.
2.  **Client-Side Logic Failure:** The `ChannelRouter` or RPC client misinterprets an ambiguous error, incorrectly assumes an attempt has failed, and launches a new, duplicative attempt via another attempt ID.

Communication over a network is unreliable; a remote client can time out and lack certainty on whether its request was processed, lost, or whether the server's acknowledgement of the request was lost. To navigate this, a remote client will need to employ principles of reliable communication in the form of: client supplied request IDs, retries, acknowledgements, idempotent APIs and sound error handling.

## Change Description
This PR is a first foundational step. It does not introduce the RPC itself, but instead adds the underlying storage mechanism that makes idempotence possible. We introduce a new `AttemptStore` interface and expand its `kvdb`-backed implementation, the `networkResultStore`, to include two new methods. This allows us to durably persist a record of intent to dispatch an HTLC _**prior**_ to that HTLC being forwarded.

The core primitives this new store provides are:

1.  `s.attemptStore.InitAttempt(attemptID)`: This serves as a "durable write of intent" or "write-ahead log," checkpointing the existence of an attempt **_prior_** to dispatch. It creates a record in a new `PENDING` state, guaranteeing that any subsequent call for the same ID will be rejected as a duplicate.
2.  `s.attemptStore.FailPendingAttempt(attemptID)`: This provides a mechanism to transition an initialized attempt to a terminally failed state. This prevents accrual of initialized attempts which are not actually dispatched. Such orphaned `PENDING` attempts would otherwise cause `GetAttemptResult` subscribers to hang waiting on a result which will never arrive.

NOTE: An effort is made in this branch to _"preserve the core"_ htlc dispatch logic. To minimize the risk of regressions for existing `lnd` users, this work will leave the critical-path logic of `htlcswitch.SendHTLC` and the `routing.paymentLifecycle` completely untouched. All new logic will be implemented at the `switchrpc` boundary. It also appears possible to achieve our goal _without_ modifying the on-disk structure of the [`networkResult`](https://github.com/lightningnetwork/lnd/blob/v0.19.1-beta/htlcswitch/payment_result.go#L48) type. The idea is to overload the use of the `lnwire.Msg` field to encode a third state besides `Settle/Fail`—namely, `PENDING`.

With the introduction of the `PENDING` state, we update the primary user of the attempt store, `GetAttemptResult`. Previously, a tracking request that raced ahead of a full HTLC dispatch could receive a misleading `ErrPaymentIDNotFound`. Now, when `GetAttemptResult` encounters an attempt in the `PENDING` state, the store returns `htlcswitch.ErrAttemptResultPending`. This signal is used to correctly subscribe to the future outcome rather than returning an error, ensuring the tracker safely waits for the definitive result. This makes the entire tracking lifecycle robust against dispatch request race conditions which external routers may otherwise encounter.

### Future Work
*  Introduce the new `switchrpc` sub-server with a `SendOnion` RPC that uses the `AttemptStore` to provide an idempotent API.

## Steps to Test
- All `htlcswitch` and `routing` unit tests pass.
- New unit tests for the `networkResultStore` have been added to verify the `InitAttempt`, `FailPendingAttempt`, and `cleanupOrphanedAttempts` logic.
- Built a development version of _**lnd**_ with the full change set (including #9489) and ran in an _**itest**_ suite with _**switchrpc**_ client.
