### PR TITLE
 multi: prevent duplicates for locally dispatched HTLC attempts

### DIFF
--- a/docs/release-notes/release-notes-0.21.0.md
+++ b/docs/release-notes/release-notes-0.21.0.md
@@ -75,6 +75,23 @@
 
 ## Breaking Changes
 
+* Added [duplicate safety to `switch.SendHTLC`](https://github.com/lightningnetwork/lnd/pull/10049). This method will no longer
+  forward an onion with the same attempt ID twice without the result for a given
+  ID having been cleaned from the network result store. This ensures "at most
+  once" delivery and request processing of a given HTLC attempt, allowing a
+  remote router or rpc client to safely retry htlc dispatch requests without
+  creating duplicate attempts. This extends the more narrow duplicate safety
+  already provided by the Switch’s `CircuitMap`.
+
+* The `ChannelRouter` has been updated to robustly handle the new error contract
+  from the idempotent `switch.SendHTLC` function. When faced with a persistent
+  and ambiguous dispatch error, the router will now prioritize fund safety by
+  halting the payment's life-cycle manager. This prevents a class of bugs where
+  an ambiguous error could be misinterpreted, potentially leading to a duplicate
+  payment. Final resolution of the ambiguous attempt is safely deferred to the
+  router's attempt resumption logic on restart.
+
+
 ## Performance Improvements
 
 ## Deprecations

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -554,6 +554,26 @@ type AttemptStore interface {
 	// network.
 	StoreResult(attemptID uint64, result *networkResult) error
 
+	// FailPendingAttempt transitions an initialized attempt from an
+	// initialized to a failed state and records the provided reason. This
+	// is the synchronous rollback mechanism for attempts that fail before
+	// being committed to the forwarding engine. It returns an error if the
+	// underlying storage fails.
+	FailPendingAttempt(attemptID uint64, reason *LinkError) error
+
+	// FetchPendingAttempts returns a list of all attempt IDs that are
+	// currently in the pending state.
+	//
+	// NOTE: This function is primarily used by the Switch's startup logic
+	// to identify and clean up internally orphaned payment attempts. These
+	// occur when an attempt is initialized via InitAttempt but a crash
+	// prevents its full dispatch to the network (e.g., between InitAttempt
+	// and CommitCircuits). By fetching these pending attempts, the Switch
+	// can transition their state to FAILED, preventing external callers
+	// from indefinitely hanging on GetAttemptResult for an un-dispatched
+	// attempt.
+	FetchPendingAttempts() ([]uint64, error)
+
 	// GetResult returns the network result for the specified attempt ID if
 	// it's available.
 	//

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -104,9 +104,9 @@ func newNetworkResultStore(db kvdb.Backend) *networkResultStore {
 	}
 }
 
-// storeResult stores the networkResult for the given attemptID, and notifies
+// StoreResult stores the networkResult for the given attemptID, and notifies
 // any subscribers.
-func (store *networkResultStore) storeResult(attemptID uint64,
+func (store *networkResultStore) StoreResult(attemptID uint64,
 	result *networkResult) error {
 
 	// We get a mutex for this attempt ID. This is needed to ensure
@@ -152,9 +152,9 @@ func (store *networkResultStore) storeResult(attemptID uint64,
 	return nil
 }
 
-// subscribeResult is used to get the HTLC attempt result for the given attempt
+// SubscribeResult is used to get the HTLC attempt result for the given attempt
 // ID.  It returns a channel on which the result will be delivered when ready.
-func (store *networkResultStore) subscribeResult(attemptID uint64) (
+func (store *networkResultStore) SubscribeResult(attemptID uint64) (
 	<-chan *networkResult, error) {
 
 	// We get a mutex for this payment ID. This is needed to ensure
@@ -214,7 +214,7 @@ func (store *networkResultStore) subscribeResult(attemptID uint64) (
 
 // getResult attempts to immediately fetch the result for the given pid from
 // the store. If no result is available, ErrPaymentIDNotFound is returned.
-func (store *networkResultStore) getResult(pid uint64) (
+func (store *networkResultStore) GetResult(pid uint64) (
 	*networkResult, error) {
 
 	var result *networkResult
@@ -253,12 +253,12 @@ func fetchResult(tx kvdb.RTx, pid uint64) (*networkResult, error) {
 	return deserializeNetworkResult(r)
 }
 
-// cleanStore removes all entries from the store, except the payment IDs given.
+// CleanStore removes all entries from the store, except the payment IDs given.
 // NOTE: Since every result not listed in the keep map will be deleted, care
 // should be taken to ensure no new payment attempts are being made
 // concurrently while this process is ongoing, as its result might end up being
 // deleted.
-func (store *networkResultStore) cleanStore(keep map[uint64]struct{}) error {
+func (store *networkResultStore) CleanStore(keep map[uint64]struct{}) error {
 	return kvdb.Update(store.backend, func(tx kvdb.RwTx) error {
 		networkResults, err := tx.CreateTopLevelBucket(
 			networkResultStoreBucketKey,

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -118,7 +118,7 @@ func TestNetworkResultStore(t *testing.T) {
 	// Subscribe to 2 of them.
 	var subs []<-chan *networkResult
 	for i := uint64(0); i < 2; i++ {
-		sub, err := store.subscribeResult(i)
+		sub, err := store.SubscribeResult(i)
 		if err != nil {
 			t.Fatalf("unable to subscribe: %v", err)
 		}
@@ -127,7 +127,7 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Store three of them.
 	for i := uint64(0); i < 3; i++ {
-		err := store.storeResult(i, results[i])
+		err := store.StoreResult(i, results[i])
 		if err != nil {
 			t.Fatalf("unable to store result: %v", err)
 		}
@@ -144,7 +144,7 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Let the third one subscribe now. THe result should be received
 	// immediately.
-	sub, err := store.subscribeResult(2)
+	sub, err := store.SubscribeResult(2)
 	require.NoError(t, err, "unable to subscribe")
 	select {
 	case <-sub:
@@ -154,22 +154,22 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Try fetching the result directly for the non-stored one. This should
 	// fail.
-	_, err = store.getResult(3)
+	_, err = store.GetResult(3)
 	if err != ErrPaymentIDNotFound {
 		t.Fatalf("expected ErrPaymentIDNotFound, got %v", err)
 	}
 
 	// Add the result and try again.
-	err = store.storeResult(3, results[3])
+	err = store.StoreResult(3, results[3])
 	require.NoError(t, err, "unable to store result")
 
-	_, err = store.getResult(3)
+	_, err = store.GetResult(3)
 	require.NoError(t, err, "unable to get result")
 
 	// Since we don't delete results from the store (yet), make sure we
 	// will get subscriptions for all of them.
 	for i := uint64(0); i < numResults; i++ {
-		sub, err := store.subscribeResult(i)
+		sub, err := store.SubscribeResult(i)
 		if err != nil {
 			t.Fatalf("unable to subscribe: %v", err)
 		}
@@ -187,12 +187,12 @@ func TestNetworkResultStore(t *testing.T) {
 		1: {},
 	}
 	// Finally, delete the result.
-	err = store.cleanStore(toKeep)
+	err = store.CleanStore(toKeep)
 	require.NoError(t, err)
 
 	// Payment IDs 0 and 1 should be found, 2 and 3 should be deleted.
 	for i := uint64(0); i < numResults; i++ {
-		_, err = store.getResult(i)
+		_, err = store.GetResult(i)
 		if i <= 1 {
 			require.NoError(t, err, "unable to get result")
 		}

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1901,6 +1901,13 @@ func (s *Switch) Start() error {
 
 	log.Infof("HTLC Switch starting")
 
+	// Before starting the main event loop, we'll check for any orphaned
+	// HTLC attempts that may have been left behind by a previous crash.
+	if err := s.cleanupOrphanedAttempts(); err != nil {
+		return fmt.Errorf("failed to cleanup orphaned attempts: %w",
+			err)
+	}
+
 	blockEpochStream, err := s.cfg.Notifier.RegisterBlockEpochNtfn(nil)
 	if err != nil {
 		return err
@@ -1921,6 +1928,88 @@ func (s *Switch) Start() error {
 		_ = s.Stop()
 		log.Errorf("unable to reforward resolutions: %v", err)
 		return err
+	}
+
+	return nil
+}
+
+// cleanupOrphanedAttempts is a helper function that is called on startup to
+// clean up any orphaned HTLC attempts. An orphaned attempt is one that has
+// been initialized in the attempt store but for which no corresponding circuit
+// exists in the circuit map. This can happen if the node crashes after
+// initializing an attempt but before committing the circuit.
+func (s *Switch) cleanupOrphanedAttempts() error {
+	pending, err := s.attemptStore.FetchPendingAttempts()
+	if err != nil {
+		return fmt.Errorf("failed to fetch pending attempts: %w", err)
+	}
+
+	if len(pending) == 0 {
+		return nil
+	}
+
+	log.Infof("Found %d pending HTLC attempts, checking for orphans",
+		len(pending))
+
+	for _, attemptID := range pending {
+		// For each pending attempt, we check if a corresponding circuit
+		// exists.
+		inKey := CircuitKey{
+			ChanID: hop.Source,
+			HtlcID: attemptID,
+		}
+		circuit := s.circuits.LookupCircuit(inKey)
+
+		// If no circuit exists, this is an orphan from a crash
+		// between InitAttempt and CommitCircuits. We'll fail it with
+		// a temporary node failure.
+		if circuit == nil {
+			log.Warnf("Found orphaned HTLC attempt with id %d "+
+				"(no circuit), failing", attemptID)
+
+			err := s.attemptStore.FailPendingAttempt(
+				attemptID,
+				NewLinkError(
+					&lnwire.FailTemporaryNodeFailure{},
+				),
+			)
+			if err != nil {
+				log.Errorf("Unable to fail orphaned attempt "+
+					"%d: %v", attemptID, err)
+			}
+
+			continue
+		}
+
+		// If a circuit *does* exist, we must perform a second check.
+		// If the circuit is still "half-open" (it has not been
+		// assigned a keystone by the outgoing link), then it's an
+		// orphan from a crash between CommitCircuits and the handoff
+		// to the link. We must also fail this to prevent a hang.
+		//
+		// TODO(calvin): cleanup of dangling circuits for locally
+		// initated payments as described here:
+		// https://github.com/lightningnetwork/lnd/issues/10423.
+		if !circuit.HasKeystone() {
+			log.Warnf("Found orphaned HTLC attempt with id %d "+
+				"(half-open circuit), failing", attemptID)
+
+			err := s.attemptStore.FailPendingAttempt(
+				attemptID,
+				NewLinkError(
+					&lnwire.FailTemporaryNodeFailure{},
+				),
+			)
+			if err != nil {
+				log.Errorf("Unable to fail orphaned attempt "+
+					"%d: %v", attemptID, err)
+			}
+
+			continue
+		}
+
+		// If the circuit exists and is fully open, it's a legitimate
+		// in-flight HTLC that will be resumed by the router.
 	}
 
 	return nil

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -561,16 +561,92 @@ func (s *Switch) CleanStore(keepPids map[uint64]struct{}) error {
 	return s.attemptStore.CleanStore(keepPids)
 }
 
-// SendHTLC is used by other subsystems which aren't belong to htlc switch
-// package in order to send the htlc update. The attemptID used MUST be unique
-// for this HTLC, and MUST be used only once, otherwise the switch might reject
-// it.
+// SendHTLC is the idempotent, safe entry point for local subsystems to dispatch
+// a payment attempt. If a dispatch error occurs, the attempt is transitioned
+// to a terminal FAILED state before returning the error. This prevents the
+// attempt from being left pending and clarifies it is not in-flight. A return
+// of ErrDuplicateAdd indicates the dispatch for this attempt was already
+// acknowledged. The attempt may be in-flight, or it may already have a terminal
+// (settle or fail) result. The caller MUST use GetAttemptResult to determine
+// the definitive outcome. This allows callers to reliably resume their payment
+// lifecycle after ambiguous failures, such as a restart or network timeout.
 func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 	htlc *lnwire.UpdateAddHTLC) error {
 
-	// Generate and send new update packet, if error will be received on
-	// this stage it means that packet haven't left boundaries of our
-	// system and something wrong happened.
+	// First, we initialize the attempt in our persistent store. This serves
+	// as a durable record of our intent to send and gates the attempt id
+	// for concurrent callers, allowing them to safely retry.
+	//
+	// NOTE: This MUST be the first significant action. Any pure static
+	// validation (checks on immutable request data) can happen before
+	// this, but all dynamic validation (checks against the mutable state
+	// of the world like channel capacity or peer connectivity) must
+	// happen *after* this to uphold the idempotency contract.
+	err := s.attemptStore.InitAttempt(attemptID)
+	if err != nil {
+		if errors.Is(err, ErrPaymentIDAlreadyExists) {
+			// An existing record for this attempt ID was found. We
+			// return a distinct error to signal that dispatch is
+			// acknowledged and that the caller can safely proceed
+			// to track the result.
+			log.Debugf("Attempt id=%v already exists", attemptID)
+
+			return ErrDuplicateAdd
+		}
+
+		// If we receive an initialization error, we'll return the error
+		// directly to the caller so they can handle the ambiguity.
+		log.Errorf("Unable to initialize attempt id=%d: %v",
+			attemptID, err)
+
+		return err
+	}
+
+	// With the attempt initialized, we now dispatch the HTLC.
+	dispatchErr := s.DispatchHTLC(firstHop, attemptID, htlc)
+
+	// If dispatch failed, the HTLC is not in-flight. We must ensure that
+	// the attempt, which was initialized via InitAttempt, does not remain
+	// in a pending state if it was never actually dispatched. To resolve
+	// this ambiguity, we fail the attempt, transitioning it to a terminal
+	// FAILED state. This prevents a caller from hanging on an initialized
+	// but un-dispatched attempt.
+	if dispatchErr != nil {
+		// For plain errors (fee exceeded, duplicate, etc.), we create a
+		// generic LinkError for the internal rollback.
+		var linkErrLocal *LinkError
+		if !errors.As(dispatchErr, &linkErrLocal) {
+			linkErrLocal = NewLinkError(
+				&lnwire.FailTemporaryNodeFailure{},
+			)
+		}
+
+		err = s.attemptStore.FailPendingAttempt(attemptID, linkErrLocal)
+		if err != nil {
+			log.Errorf("Unable to store failure result for "+
+				"attempt %d: %v. Orphaned pending attempt may "+
+				"exist until next restart", attemptID, err)
+		}
+
+		// Return the original, more specific error to the caller.
+		return dispatchErr
+	}
+
+	return nil
+}
+
+// DispatchHTLC contains the core, non-idempotent dispatch logic. It serves as
+// the primary building block for safe, idempotent wrappers like SendHTLC (for
+// local subsystems) and remote handlers like the SendOnion gRPC endpoint.
+//
+// NOTE: This method must only be called by a safe wrapper that uses InitAttempt
+// to provide lifecycle-level idempotency. While this method relies on the
+// CircuitMap to prevent duplicate *in-flight* HTLCs, it does not prevent the
+// re-use of an attemptID after a payment has already resolved.
+func (s *Switch) DispatchHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
+	htlc *lnwire.UpdateAddHTLC) error {
+
+	// Create the packet that will be sent to the link.
 	packet := &htlcPacket{
 		incomingChanID: hop.Source,
 		incomingHTLCID: attemptID,
@@ -578,6 +654,30 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 		htlc:           htlc,
 		amount:         htlc.Amount,
 	}
+
+	// First, perform all local validation for the outgoing HTLC.
+	link, err := s.validateOutgoingHTLC(packet, htlc)
+	if err != nil {
+		return err
+	}
+
+	// With the link validated, commit the payment circuit. This provides a
+	// line of defense preventing duplicates for in-flight HTLCs.
+	if err := s.commitHTLCCircuit(packet, htlc); err != nil {
+		return err
+	}
+
+	// The circuit has now been committed. From this point on, any failures
+	// are handled by the switch's asynchronous resolution mechanisms.
+	// Deliver the packet to the outgoing link.
+	return link.handleSwitchPacket(packet)
+}
+
+// validateOutgoingHTLC performs local validation checks for an outgoing HTLC,
+// including link availability and dust/fee exposure checks. It returns the
+// target link if all validations pass.
+func (s *Switch) validateOutgoingHTLC(packet *htlcPacket,
+	htlc *lnwire.UpdateAddHTLC) (ChannelLink, error) {
 
 	// Attempt to fetch the target link before creating a circuit so that
 	// we don't leave dangling circuits. The getLocalLink method does not
@@ -598,7 +698,7 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 			false,
 		)
 
-		return linkErr
+		return nil, linkErr
 	}
 
 	// Evaluate whether this HTLC would bypass our fee exposure. If it
@@ -621,8 +721,17 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 			false,
 		)
 
-		return errFeeExposureExceeded
+		return nil, errFeeExposureExceeded
 	}
+
+	return link, nil
+}
+
+// commitHTLCCircuit creates and commits a payment circuit for the given HTLC.
+// It handles duplicate detection and attaches the circuit to the packet if
+// successful.
+func (s *Switch) commitHTLCCircuit(packet *htlcPacket,
+	htlc *lnwire.UpdateAddHTLC) error {
 
 	circuit := newPaymentCircuit(&htlc.PaymentHash, packet)
 	actions, err := s.circuits.CommitCircuits(circuit)
@@ -644,7 +753,7 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 	// canceled back if the mailbox timeout elapses.
 	packet.circuit = circuit
 
-	return link.handleSwitchPacket(packet)
+	return nil
 }
 
 // UpdateForwardingPolicies sends a message to the switch to update the

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -3106,7 +3106,7 @@ func TestSwitchGetAttemptResult(t *testing.T) {
 		isResolution: true,
 	}
 
-	err = s.networkResults.storeResult(paymentID, n)
+	err = s.attemptStore.StoreResult(paymentID, n)
 	require.NoError(t, err, "unable to store result")
 
 	// The result should be available.

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -5601,7 +5601,6 @@ func TestSwitchDuplicateAttemptPrevention(t *testing.T) {
 		"to fail while in-flight")
 
 	// --- Subtest 2: Duplicate after result rejected ---
-
 	// Launch a routine to await the result of the HTLC attempt.
 	errChan := make(chan error, 1)
 	go func() {
@@ -5787,5 +5786,133 @@ func TestSwitchGetAttemptResultHangsOnOrphanedAttempt(t *testing.T) {
 		require.Error(t, result.Error, "expected a failed result")
 	case <-time.After(1 * time.Second):
 		t.Fatalf("did not receive result after manual failure")
+	}
+}
+
+// TestSwitchOrphanCleanup tests that the switch's startup procedure will
+// correctly identify and clean up any orphaned attempts. This includes both
+// simple pending orphans (from a crash after InitAttempt) and "half-open"
+// circuit orphans (from a crash after CommitCircuits).
+func TestSwitchOrphanCleanup(t *testing.T) {
+	t.Parallel()
+
+	const attemptID = uint64(1)
+
+	testCases := []struct {
+		name        string
+		setupOrphan func(t *testing.T, s *Switch, cdb *channeldb.DB)
+	}{
+		{
+			name: "pre-commit orphan",
+			setupOrphan: func(t *testing.T, s *Switch,
+				_ *channeldb.DB) {
+
+				// Manually initialize an attempt to simulate
+				// the state of the database if the node crashed
+				// after InitAttempt but before CommitCircuits.
+				err := s.attemptStore.InitAttempt(attemptID)
+				require.NoError(t, err, "unable to init")
+			},
+		},
+		{
+			name: "half-open circuit orphan",
+			setupOrphan: func(t *testing.T, s *Switch,
+				_ *channeldb.DB) {
+
+				// Manually initialize an attempt and commit a
+				// circuit to simulate the state of the database
+				// if the node crashed after CommitCircuits but
+				// before the packet was handed off to the link.
+				err := s.attemptStore.InitAttempt(attemptID)
+				require.NoError(t, err, "unable to init")
+
+				htlc := &lnwire.UpdateAddHTLC{
+					PaymentHash: lntypes.Hash{0x01},
+				}
+
+				// We'll create a dummy outgoing channel ID to
+				// attach to the circuit. The existence of an
+				// outgoingChanID is what makes this a
+				// "half-open" orphan, as the switch knows it
+				// was intended to be forwarded somewhere.
+				const outgoingChanID = 123
+				packet := &htlcPacket{
+					incomingChanID: hop.Source,
+					incomingHTLCID: attemptID,
+					outgoingChanID: lnwire.
+						NewShortChanIDFromInt(
+							outgoingChanID,
+						),
+					htlc:   htlc,
+					amount: htlc.Amount,
+				}
+
+				circuit := newPaymentCircuit(
+					&htlc.PaymentHash, packet,
+				)
+				_, err = s.circuits.CommitCircuits(circuit)
+				require.NoError(t, err, "commit failed")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a temporary database path that will persist
+			// across restarts.
+			tempPath := t.TempDir()
+
+			// First, we'll create a database and a switch
+			// instance.
+			cdb1 := channeldb.OpenForTesting(t, tempPath)
+			s1, err := initSwitchWithDB(0, cdb1)
+			require.NoError(t, err)
+			require.NoError(t, s1.Start())
+
+			// Call the specific setup function for this test case
+			// to create the desired orphan state.
+			tc.setupOrphan(t, s1, cdb1)
+
+			// We must stop the switch and close its database to
+			// ensure the state is flushed to disk at tempPath.
+			require.NoError(t, s1.Stop())
+			require.NoError(t, cdb1.Close())
+
+			// Now, we'll create a new database instance from the
+			// same path and a new switch. This simulates a node
+			// restart.
+			cdb2 := channeldb.OpenForTesting(t, tempPath)
+			t.Cleanup(func() { cdb2.Close() })
+
+			s2, err := initSwitchWithDB(0, cdb2)
+			require.NoError(t, err)
+			require.NoError(t, s2.Start())
+			t.Cleanup(func() { require.NoError(t, s2.Stop()) })
+
+			// After startup, we query the store for our orphaned
+			// attempt ID. We expect to find a final FAILED
+			// result, as the janitor should have cleaned it up.
+			result, err := s2.attemptStore.GetResult(attemptID)
+			require.NoError(t, err, "expected final result")
+			require.NotNil(t, result, "result should not be nil")
+
+			// The result should be a failure message.
+			failMsg, ok := result.msg.(*lnwire.UpdateFailHTLC)
+			require.True(t, ok, "expected fail message")
+
+			// The cleanup routine uses a generic failure reason.
+			require.True(t, result.unencrypted, "unencrypted")
+			reason, err := lnwire.DecodeFailure(
+				bytes.NewReader(failMsg.Reason), 0,
+			)
+			require.NoError(t, err, "unable to decode failure")
+
+			// We expect a FailTemporaryNodeFailure.
+			_, ok = reason.(*lnwire.FailTemporaryNodeFailure)
+			require.True(t, ok, "expected temp node failure")
+		})
 	}
 }

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -1,6 +1,7 @@
 package htlcswitch
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"errors"
@@ -5553,4 +5554,238 @@ func testSwitchAliasInterceptFail(t *testing.T, zeroConf bool) {
 	}
 
 	require.NoError(t, interceptSwitch.Stop())
+}
+
+// TestSwitchDuplicateAttemptPrevention validates the behavior of the Switch and
+// its underlying stores with respect to re-use of HTLC attempt ID. We expect
+// the Switch to guarantee that only one HTLC will be forwarded for a given
+// attemptID until the ID is explicitly cleaned from the underlying attempt
+// store.
+func TestSwitchDuplicateAttemptPrevention(t *testing.T) {
+	t.Parallel()
+
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil,
+		testDefaultDelta)
+	require.NoError(t, err)
+
+	s, err := initSwitchWithTempDB(t, testStartingHeight)
+	require.NoError(t, err)
+	require.NoError(t, s.Start())
+	defer func() { _ = s.Stop() }()
+
+	chanID, _, aliceChanID, _ := genIDs()
+
+	aliceLink := newMockChannelLink(
+		s, chanID, aliceChanID, emptyScid,
+		alicePeer, true, false, false, false,
+	)
+	require.NoError(t, s.AddLink(aliceLink))
+
+	preimage, err := genPreimage()
+	require.NoError(t, err)
+	rhash := sha256.Sum256(preimage[:])
+	attemptID := uint64(123)
+
+	update := &lnwire.UpdateAddHTLC{
+		PaymentHash: rhash,
+		Amount:      lnwire.NewMSatFromSatoshis(1000),
+		ChanID:      chanID,
+	}
+
+	// --- Subtest 1: Duplicate in-flight attempt ---
+	err = s.SendHTLC(aliceLink.ShortChanID(), attemptID, update)
+	require.NoError(t, err, "expected first SendHTLC to succeed")
+
+	err = s.SendHTLC(aliceLink.ShortChanID(), attemptID, update)
+	require.ErrorIs(t, err, ErrDuplicateAdd, "expected duplicate attempt "+
+		"to fail while in-flight")
+
+	// --- Subtest 2: Duplicate after result rejected ---
+
+	// Launch a routine to await the result of the HTLC attempt.
+	errChan := make(chan error, 1)
+	go func() {
+		resultChan, err := s.GetAttemptResult(
+			attemptID, rhash,
+			newMockDeobfuscator(),
+		)
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		result, ok := <-resultChan
+		if !ok {
+			errChan <- fmt.Errorf("result channel closed")
+			return
+		}
+		if result.Error != nil {
+			errChan <- result.Error
+			return
+		}
+		if result.Preimage != preimage {
+			errChan <- fmt.Errorf("preimage mismatch")
+			return
+		}
+		errChan <- nil
+	}()
+
+	select {
+	case pkt := <-aliceLink.packets:
+		require.NoError(t, aliceLink.completeCircuit(pkt))
+	case <-time.After(time.Second):
+		t.Fatal("packet not received")
+	}
+
+	// Send fulfillment packet.
+	settlePkt := &htlcPacket{
+		outgoingChanID: aliceLink.ShortChanID(),
+		outgoingHTLCID: 0,
+		htlc: &lnwire.UpdateFulfillHTLC{
+			PaymentPreimage: preimage,
+		},
+		amount: lnwire.NewMSatFromSatoshis(1000),
+	}
+	require.NoError(t, s.ForwardPackets(nil, settlePkt))
+
+	// The SendHTLC goroutine should complete successfully.
+	select {
+	case err := <-errChan:
+		require.NoError(t, err, "expected HTLC to complete "+
+			"successfully")
+	case <-time.After(time.Second):
+		t.Fatal("did not receive result")
+	}
+
+	// Attempt to reuse the attempt ID after the full settle or fail result
+	// is back from the network.
+	err = s.SendHTLC(aliceLink.ShortChanID(), attemptID, update)
+	require.ErrorIs(t, err, ErrDuplicateAdd, "expected reuse after result "+
+		"to fail")
+
+	// Verify that ID can be re-used only after explicit deletion of
+	// attempts via CleanStore or a DeleteAttempts style method.
+	err = s.CleanStore(map[uint64]struct{}{})
+	require.NoError(t, err)
+
+	// Now SendHTLC will permit the ID to be re-used again.
+	err = s.SendHTLC(aliceLink.ShortChanID(), attemptID, update)
+	require.NoError(t, err, "expected first SendHTLC to succeed")
+}
+
+// TestSwitchSendHTLCSyncRollback tests that if SendHTLC fails after the
+// attempt has been initialized, a final failure result is synchronously
+// stored in the attempt store. This is critical to prevent callers of
+// GetAttemptResult from hanging indefinitely.
+func TestSwitchSendHTLCSyncRollback(t *testing.T) {
+	t.Parallel()
+
+	// Create a new switch with a persistent attempt store.
+	s, err := initSwitchWithTempDB(t, 0)
+	require.NoError(t, err)
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { require.NoError(t, s.Stop()) })
+
+	// We will attempt to send an HTLC to a non-existent channel. This will
+	// cause SendHTLC to fail *after* the attempt has been initialized.
+	invalidScid := lnwire.NewShortChanIDFromInt(123)
+	attemptID := uint64(1)
+	htlc := &lnwire.UpdateAddHTLC{}
+
+	// The call to SendHTLC should fail.
+	err = s.SendHTLC(invalidScid, attemptID, htlc)
+	var linkErr *LinkError
+	require.ErrorAs(t, err, &linkErr)
+
+	// Now, we check the attempt store for the result. We expect to find a
+	// final FAILED result, not ErrPaymentIDNotFound or
+	// ErrAttemptResultPending.
+	result, err := s.attemptStore.GetResult(attemptID)
+	require.NoError(t, err, "expected to find a final result")
+	require.NotNil(t, result, "result should not be nil")
+
+	// The result should be a failure message.
+	failMsg, ok := result.msg.(*lnwire.UpdateFailHTLC)
+	require.True(t, ok, "expected an UpdateFailHTLC message")
+
+	// Since this was a local failure, the reason should be an unencrypted
+	// failure message that we can decode.
+	require.True(t, result.unencrypted, "expected unencrypted failure")
+	reason, err := lnwire.DecodeFailure(
+		bytes.NewReader(failMsg.Reason), 0,
+	)
+	require.NoError(t, err, "unable to decode failure reason")
+
+	// We expect the specific failure to be an UnknownNextPeer error, since
+	// that's what our SendHTLC call should have failed with.
+	_, ok = reason.(*lnwire.FailUnknownNextPeer)
+	require.True(t, ok, "expected unknown next peer failure")
+
+	// Now, we'll call GetAttemptResult. Since the synchronous rollback
+	// should have already stored a final result, we expect this call to
+	// return immediately with a failed result.
+	resChan, err := s.GetAttemptResult(attemptID, lntypes.Hash{}, nil)
+	require.NoError(t, err, "GetAttemptResult should not fail")
+
+	// We expect to receive a result immediately.
+	select {
+	case result := <-resChan:
+		// The result should be a failure.
+		require.Error(t, result.Error, "expected a failed result")
+
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("GetAttemptResult should have returned immediately")
+	}
+}
+
+// TestSwitchGetAttemptResultHangsOnOrphanedAttempt tests that a caller to
+// GetAttemptResult will hang if an attempt is orphaned in the pending state,
+// and that the synchronous rollback (via FailPendingAttempt) fixes this.
+func TestSwitchGetAttemptResultHangsOnOrphanedAttempt(t *testing.T) {
+	t.Parallel()
+
+	s, err := initSwitchWithTempDB(t, 0)
+	require.NoError(t, err)
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { require.NoError(t, s.Stop()) })
+
+	// Manually initialize an attempt in the store. This simulates the "bad"
+	// state where an attempt is pending but has no corresponding circuit,
+	// which our SendHTLC changes are designed to prevent.
+	attemptID := uint64(1)
+	err = s.attemptStore.InitAttempt(attemptID)
+	require.NoError(t, err, "unable to initialize attempt")
+
+	// Now, call GetAttemptResult. This function returns a channel that will
+	// deliver the result.
+	resChan, err := s.GetAttemptResult(
+		attemptID, lntypes.Hash{}, nil,
+	)
+	require.NoError(t, err)
+
+	// We expect the call to hang. We'll use a timeout to verify that no
+	// result is received from the channel.
+	select {
+	case <-resChan:
+		t.Fatalf("received result unexpectedly, should have hung")
+	case <-time.After(100 * time.Millisecond):
+		// This is the expected path, the call has "hung" for 100ms.
+	}
+
+	// Now, simulate the fix by manually calling FailPendingAttempt. This is
+	// what SendHTLC now does synchronously on failure.
+	err = s.attemptStore.FailPendingAttempt(attemptID, NewLinkError(
+		&lnwire.FailTemporaryNodeFailure{}),
+	)
+	require.NoError(t, err, "unable to fail attempt")
+
+	// The channel should now un-block and deliver the final failed
+	// result.
+	select {
+	case result := <-resChan:
+		// We expect a result with an error, indicating failure.
+		require.Error(t, result.Error, "expected a failed result")
+	case <-time.After(1 * time.Second):
+		t.Fatalf("did not receive result after manual failure")
+	}
 }

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -700,6 +700,23 @@ func (p *paymentLifecycle) sendAttempt(
 	// restart.
 	err = p.router.cfg.Payer.SendHTLC(firstHop, attempt.AttemptID, htlcAdd)
 	if err != nil {
+		// The dispatcher has confirmed that this attempt was already
+		// processed and is in-flight. Though this is unexpected, we can
+		// handle it gracefully by treating it as an acknowledgment of a
+		// successful dispatch and proceed to tracking the result.
+		if errors.Is(err, htlcswitch.ErrDuplicateAdd) {
+			log.Warnf("Attempt %v for payment %v already "+
+				"processed by dispatcher (duplicate). "+
+				"Proceeding to result collection.",
+				attempt.AttemptID, p.identifier)
+
+			return &attemptResult{
+				attempt: attempt,
+			}, nil
+		}
+
+		// If it's any other error, then it's a genuine failure that
+		// needs to be handled by the switch error handler.
 		log.Errorf("Failed sending attempt %d for payment %v to "+
 			"switch: %v", attempt.AttemptID, p.identifier, err)
 

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -715,8 +715,29 @@ func (p *paymentLifecycle) sendAttempt(
 			}, nil
 		}
 
-		// If it's any other error, then it's a genuine failure that
-		// needs to be handled by the switch error handler.
+		// The dispatcher has encountered a persistent, unresolvable
+		// ambiguous error (e.g., a DB failure). The state of the
+		// attempt is unknown. We must prioritize safety over liveness
+		// by executing a "fail-safe shutdown" for this payment. The
+		// payment will remain in-flight in the database and will be
+		// correctly resumed after the next node restart.
+		// TODO(calvin): consider adding retries here to resolve without
+		// needing a restart.
+		if errors.Is(err, htlcswitch.ErrAmbiguousAttemptInit) {
+			log.Warnf("Ambiguous result for attempt %v on payment "+
+				"%v. Terminating payment lifecycle and "+
+				"deferring resolution to restart.",
+				attempt.AttemptID, p.identifier)
+
+			// Return a critical, payment-terminating error.
+			return nil, fmt.Errorf("unresolved ambiguity for "+
+				"attempt %v: %w", attempt.AttemptID,
+				htlcswitch.ErrAmbiguousAttemptInit)
+		}
+
+		// If it's any other error, then it's a genuine, definitive
+		// failure that needs to be handled by the switch error
+		// handler.
 		log.Errorf("Failed sending attempt %d for payment %v to "+
 			"switch: %v", attempt.AttemptID, p.identifier, err)
 

--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -1966,3 +1966,84 @@ func TestResumePaymentErrDuplicateAdd(t *testing.T) {
 	// ErrDuplicateAdd was handled as a success.
 	require.Equal(t, 1, m.collectResultsCount)
 }
+
+// TestResumePaymentErrAmbiguousAttemptInit tests that when the dispatcher
+// returns ErrAmbiguousAttemptInit, the router executes the "Halt and
+// Terminate" strategy, returning a critical error to the caller.
+//
+// NOTE: No parallel test because it overwrites global variables.
+//
+//nolint:paralleltest
+func TestResumePaymentErrAmbiguousAttemptInit(t *testing.T) {
+	// Create a test paymentLifecycle with the initial two calls mocked.
+	p, m := setupTestPaymentLifecycle(t)
+
+	// Create a dummy route that will be returned by `RequestRoute`.
+	paymentAmt := lnwire.MilliSatoshi(10000)
+	rt := createDummyRoute(t, paymentAmt)
+
+	// We now enter the payment lifecycle loop.
+	//
+	// 1. calls `FetchPayment` and return the payment.
+	m.control.On("FetchPayment", p.identifier).Return(m.payment, nil).Once()
+
+	// 2. calls `GetState` and return the state.
+	ps := &paymentsdb.MPPaymentState{
+		RemainingAmt: paymentAmt,
+	}
+	m.payment.On("GetState").Return(ps).Once()
+
+	// NOTE: GetStatus is only used to populate the logs which is
+	// not critical so we loosen the checks on how many times it's
+	// been called.
+	m.payment.On("GetStatus").Return(paymentsdb.StatusInFlight)
+
+	// 3. decideNextStep now returns stepProceed.
+	m.payment.On("AllowMoreAttempts").Return(true, nil).Once()
+
+	// 4. mock requestRoute to return an route.
+	m.paySession.On("RequestRoute",
+		paymentAmt, p.feeLimit, uint32(ps.NumAttemptsInFlight),
+		uint32(p.currentHeight), mock.Anything,
+	).Return(rt, nil).Once()
+
+	// 5. mock `registerAttempt` to return an attempt.
+	//
+	// Mock NextPaymentID to always return the attemptID.
+	attemptID := uint64(1)
+	p.router.cfg.NextPaymentID = func() (uint64, error) {
+		return attemptID, nil
+	}
+
+	// Mock shardTracker to return the mock shard.
+	m.shardTracker.On("NewShard",
+		attemptID, true,
+	).Return(m.shard, nil).Once()
+
+	// Mock the methods on the shard.
+	m.shard.On("MPP").Return(&record.MPP{}).Twice().
+		On("AMP").Return(nil).Once().
+		On("Hash").Return(p.identifier).Once()
+
+	// Mock the time and expect it to be called once.
+	m.clock.On("Now").Return(time.Now()).Once()
+
+	// We now register attempt and return no error.
+	m.control.On("RegisterAttempt",
+		p.identifier, mock.Anything,
+	).Return(nil).Once()
+
+	// 6. mock `sendAttempt` to return an ambiguous error.
+	m.payer.On("SendHTLC",
+		mock.Anything, attemptID, mock.Anything,
+	).Return(htlcswitch.ErrAmbiguousAttemptInit).Once()
+
+	// The above error should cause the payment lifecycle to terminate.
+	// We expect the returned error to wrap the original ambiguity error.
+	sendPaymentAndAssertError(t, t.Context(), p,
+		htlcswitch.ErrAmbiguousAttemptInit)
+
+	// Crucially, assert that no result collector was launched, as we are
+	// deferring resolution to the next restart.
+	require.Zero(t, m.collectResultsCount)
+}

--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -1862,3 +1862,107 @@ func TestReloadInflightAttemptsLegacy(t *testing.T) {
 	// Assert the result is received as expected.
 	require.Equal(t, result, r.result)
 }
+
+// TestResumePaymentErrDuplicateAdd tests that when the dispatcher returns
+// ErrDuplicateAdd, the router treats it as a successful dispatch and proceeds
+// to result collection.
+//
+// NOTE: No parallel test because it overwrites global variables.
+//
+//nolint:paralleltest
+func TestResumePaymentErrDuplicateAdd(t *testing.T) {
+	// Create a test paymentLifecycle with the initial two calls mocked.
+	p, m := setupTestPaymentLifecycle(t)
+
+	// Create a dummy route that will be returned by `RequestRoute`.
+	paymentAmt := lnwire.MilliSatoshi(10000)
+	rt := createDummyRoute(t, paymentAmt)
+
+	// We now enter the payment lifecycle loop.
+	//
+	// 1.1. calls `FetchPayment` and return the payment.
+	m.control.On("FetchPayment", p.identifier).Return(m.payment, nil).Once()
+
+	// 1.2. calls `GetState` and return the state.
+	ps := &paymentsdb.MPPaymentState{
+		RemainingAmt: paymentAmt,
+	}
+	m.payment.On("GetState").Return(ps).Once()
+
+	// NOTE: GetStatus is only used to populate the logs which is
+	// not critical so we loosen the checks on how many times it's
+	// been called.
+	m.payment.On("GetStatus").Return(paymentsdb.StatusInFlight)
+
+	// 1.3. decideNextStep now returns stepProceed.
+	m.payment.On("AllowMoreAttempts").Return(true, nil).Once()
+
+	// 1.4. mock requestRoute to return an route.
+	m.paySession.On("RequestRoute",
+		paymentAmt, p.feeLimit, uint32(ps.NumAttemptsInFlight),
+		uint32(p.currentHeight), mock.Anything,
+	).Return(rt, nil).Once()
+
+	// 1.5. mock `registerAttempt` to return an attempt.
+	//
+	// Mock NextPaymentID to always return the attemptID.
+	attemptID := uint64(1)
+	p.router.cfg.NextPaymentID = func() (uint64, error) {
+		return attemptID, nil
+	}
+
+	// Mock shardTracker to return the mock shard.
+	m.shardTracker.On("NewShard",
+		attemptID, true,
+	).Return(m.shard, nil).Once()
+
+	// Mock the methods on the shard.
+	m.shard.On("MPP").Return(&record.MPP{}).Twice().
+		On("AMP").Return(nil).Once().
+		On("Hash").Return(p.identifier).Once()
+
+	// Mock the time and expect it to be called.
+	m.clock.On("Now").Return(time.Now())
+
+	// We now register attempt and return no error.
+	m.control.On("RegisterAttempt",
+		p.identifier, mock.Anything,
+	).Return(nil).Once()
+
+	// 1.6. mock `sendAttempt` to return ErrDuplicateAdd, which should be
+	// treated as a success condition.
+	m.payer.On("SendHTLC",
+		mock.Anything, attemptID, mock.Anything,
+	).Return(htlcswitch.ErrDuplicateAdd).Once()
+
+	// The lifecycle should continue as if it were a success, eventually
+	// leading to a settled payment. We mock the rest of the success
+	// path to ensure a clean exit.
+
+	// 2.1. calls `FetchPayment` and return the payment.
+	m.control.On("FetchPayment", p.identifier).Return(m.payment, nil).Once()
+
+	// 2.2. calls `GetState` and return the state.
+	m.payment.On("GetState").Return(ps).Run(func(args mock.Arguments) {
+		ps.RemainingAmt = 0
+	}).Once()
+
+	// 2.3. decideNextStep now returns stepExit and exits the loop.
+	m.payment.On("AllowMoreAttempts").Return(false, nil).Once().
+		On("NeedWaitAttempts").Return(false, nil).Once()
+
+	// 2.4. We should perform an optional deletion over failed attempts.
+	m.control.On("DeleteFailedAttempts", p.identifier).Return(nil).Once()
+
+	// 2.5. Finally, mock the `TerminalInfo` to return a settled attempt.
+	testPreimage := lntypes.Preimage{1, 2, 3}
+	settledAttempt := makeSettledAttempt(t, int(paymentAmt), testPreimage)
+	m.payment.On("TerminalInfo").Return(settledAttempt, nil).Once()
+
+	// Send the payment and assert the preimage is matched.
+	sendPaymentAndAssertSucceeded(t, p, testPreimage)
+
+	// Assert that a result collector was launched, proving that the
+	// ErrDuplicateAdd was handled as a success.
+	require.Equal(t, 1, m.collectResultsCount)
+}

--- a/routing/router.go
+++ b/routing/router.go
@@ -106,7 +106,13 @@ type PaymentAttemptDispatcher interface {
 	// SendHTLC is a function that directs a link-layer switch to
 	// forward a fully encoded payment to the first hop in the route
 	// denoted by its public key. A non-nil error is to be returned if the
-	// payment was unsuccessful.
+	// payment was unsuccessful. A return value of ErrDuplicateAdd signals
+	// that this attempt has already been processed and that the caller
+	// should proceed to track the dispatch result via GetAttemptResult.
+	// While the dispatcher should gracefully handle duplicate `attemptID`s
+	// by returning `ErrDuplicateAdd`, callers must generate globally unique
+	// IDs for each new logical payment attempt to avoid unintended
+	// collisions.
 	SendHTLC(firstHop lnwire.ShortChannelID,
 		attemptID uint64,
 		htlcAdd *lnwire.UpdateAddHTLC) error


### PR DESCRIPTION
## Change Description

As mentioned in https://github.com/lightningnetwork/lnd/pull/9489, we intend to offload path-finding, onion construction and payment life-cycle management to an external entity (with a remotely instantiated **_ChannelRouter_** type) capable of orchestrating payments across a set of  remote _**lnd**_ instances. The _**lnd**_ instances would be relegated to accept onion payments for direct delivery to the network. Ideally _**lnd's**_ existing types could be made general enough to work in both this and more traditional deployment scenarios.

We'd like to prevent duplicate payment attempts and unintentional loss of funds when using the forthcoming _**switchrpc**_ gRPC sub-server and **_SendOnion/TrackOnion_** RPCs to dispatch and track payments https://github.com/lightningnetwork/lnd/pull/9489.

One idea is to make **_SendHTLC_** duplicate safe for given attempt ID so that callers of this function may retry until they receive an explicit and unambiguous acknowledgement from the Switch regarding the status of the request to dispatch an HTLC attempt. This appears un-interesting in the default case where _**ChannelRouter**_ and _**Switch**_ run together in a single _**lnd**_ binary, but becomes more important for correctness when the _**Router**_ and _**Switch**_ run in separate processes with synchronous communication via RPC - as there are different failure domains which must be dealt with.

This PR explores a modification to the Switch's `networkResultStore` to enable this while hopefully minimizing the necessary **_ChannelRouter/Switch_** changes. To accomplish this, we durably persist record of intent to dispatch an HTLC _**prior**_ to sending that HTLC for forwarding to the broader network. 

The  _**SendHTLC()**_ method is updated such that it is safe to call multiple times with the same attempt ID. With this change, we'd now have two writes to disk involved in the _outgoing_ HTLC dispatch flow from the perspective of the _**Switch**_. The "routing node" responsibility of forwarding of HTLCs is not impacted.

1. `s.attemptStore.InitAttempt(attemptID)`: proposed addition. updates attempt result store to checkpoint/durably mark in persistent store some information about the existence of an attempt **_prior_** to sending that attempt out to the network.
2. `s.circuits.CommitCircuits(circuit)`: exists today. tracks flow of HTLC through Switch. Does not prevent duplicates for attempts which have already received a result from the network (settle/fail).

NOTE: The Switch's `CircuitMap` offers some protection against duplicate attempts with the same ID, but the life-cycle of this protection is not tied to the Router's management of payment life-cycle (eg: `DeleteCircuits` cleans `CircuitMap` potentially prior to results being read from the Switch's attempt result store) and appears insufficient for our use case. Once a result arrives and the circuit is torn down, that attempt ID becomes reusable and thus capable of having it's result overwritten within the Switch's store - which can be tricky for remote clients which may go offline for an arbitrary length of time and need to rely on the ability to safely retry an HTLC dispatch request. 

It appears as though it is possible to achieve our aim without modifying the on-disk structure of the [`networkResult`](https://github.com/lightningnetwork/lnd/blob/v0.19.1-beta/htlcswitch/payment_result.go#L48) type used by this store. One idea is to overload the use of the `lnwire.Msg` field to allow it to encode a 3rd state besides `Settle/Fail` - namely `Initiated/Pending/In-Flight`. This seems to be the minimal required ability to be able to offer the `InitAttempt` duplicate protection which lasts the entire life-cycle of the attempt, so that the **_ChannelRouter_** and its use of the **_PaymentAttemptDispatcher_** interface can be general enough to work both in the case where **_Router_** and **_Switch_** run in the same process (as is the case for the large majority of _**lnd**_ deployments) and in the scenario where they run in different processes.

## TODO
- Modify the **_ChannelRouter_** to call _**SendHTLC**_ defensively when resuming payments after a restart. 
    - **_Local/Monolithic Deployment_**: the usual case where everything runs in a single binary. With the duplicate safety, this call harmlessly errors and we proceed to tracking the result like normal.
    - **_Remote Router Deployment_**: instantiate a type with an alternate _RPC_ backed implementation of **_SendHTLC_** which would attempt to deliver the onion via `switchrpc` **_SendOnion_** with a retry loop. The implementation of SendOnion/switch.SendHTLC executed server side would prevent any duplicates for the same ID and allow the client to safely retry until it receives a definitive response from the server. The **_ChannelRouter_** and its use of the **_PaymentAttemptDispatcher_** interface can be general enough to work both in the case where **_Router_** and **_Switch_** run in the same process (as is the case for the large majority of _**lnd**_ deployments) and in the scenario where they run in different processes.

```go
// Possibly via an alternate implementation of SendHTLC, but this pattern applies more generally.
// func (p *rpcPaymentDispatcher) SendHTLC(firstHop lnwire.ShortChannelID,
// attemptID uint64, htlcAdd *lnwire.UpdateAddHTLC) error {

       for {
               resp, err := SendOnion(A)
               if err == nil || err == ErrDuplicateAdd {
                       break // HTLC in-flight or just accepted; proceed to track
               }
               continue
       }

       // ... Sometime later possibly from another go routine (eg: Router via
       // GetAttemptResult)
       TrackOnion(A)
```

- [ ] [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

## Steps to Test
- Ran the unit tests for `htlcswitch` package locally and everything passes: `make unit-debug log="stdlog trace" pkg=htlcswitch timeout=5m`
- go test -v -timeout 30s -run ^TestNetworkResultStore$ github.com/lightningnetwork/lnd/htlcswitch
- More tests needed? ...